### PR TITLE
Fix/unificar tarjetas servicios 18

### DIFF
--- a/src/components/Features/Features.css
+++ b/src/components/Features/Features.css
@@ -20,9 +20,8 @@
 .features-grid {
   width: 100%;
   max-width: 1200px;
-  display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
   gap: 2rem;
@@ -34,6 +33,8 @@
   border-radius: 15px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
   text-align: left; /* para que el icono y título queden alineados */
+  display: flex;
+  flex-direction: column;
 }
 
 .feature-header {

--- a/src/components/Features/Features.jsx
+++ b/src/components/Features/Features.jsx
@@ -15,7 +15,7 @@ const Features = () => {
   return (
     <section className="features" id="features">
       <div className="features-container">
-        <h3 className="feature-title">Nuestras ventajas</h3>
+        <h3 className="feature-title">Servicios</h3>
         <div className="features-grid">
           {features.map((f, i) => (
             <div key={i} className="feature-card">


### PR DESCRIPTION
Se unificó el tamaño de las tarjetas en la sección Servicios para mantener una
presentación visual consistente independientemente del contenido.

## Cambios realizados
- Se ajustó el layout para que todas las tarjetas tengan el mismo alto
- Se mejoró la alineación del contenido interno
- El título de la sección se renombró para que coincida con la navegación de la barra de navegación

Closes #18
