### PR TITLE
Feature/admin cancel reservation frontend

### DIFF
--- a/src/api/adminApi.js
+++ b/src/api/adminApi.js
@@ -5,6 +5,11 @@ export const getAdminStats = async () =>{
     return response.data;
 }
 
+export const cancelReservationAdmin = async (reservationId) =>{
+    const response = await API.patch(`/admin/reservations/${reservationId}/cancel`);
+    return response.data;
+}
+
 export const getAllReservations = async () =>{
     const response = await API.get("/admin/reservations");
     return response.data;

--- a/src/components/admin/ReservationActions.jsx
+++ b/src/components/admin/ReservationActions.jsx
@@ -1,0 +1,59 @@
+import Swal from "sweetalert2";
+import { cancelReservationAdmin } from "../../api/adminApi";
+
+export default function ReservationActions({
+  reservation,
+  reloadReservations,
+}) {
+
+  const handleCancel = async () => {
+
+    const result = await Swal.fire({
+      title: "¿Cancelar reserva?",
+      text: "Esta acción no se puede deshacer",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonText: "Sí, cancelar",
+      cancelButtonText: "Volver",
+    });
+
+    if (!result.isConfirmed) return;
+
+    try {
+
+      await cancelReservationAdmin(
+        reservation.id
+      );
+
+      await Swal.fire({
+        title: "Reserva cancelada",
+        icon: "success",
+        timer: 1500,
+        showConfirmButton: false,
+      });
+
+      reloadReservations();
+
+    } catch {
+
+      Swal.fire({
+        title: "Error",
+        text: "No se pudo cancelar la reserva",
+        icon: "error",
+      });
+    }
+  };
+
+  const disabled =
+    reservation.status === "CANCELLED" ||
+    reservation.status === "EXPIRED";
+
+  return (
+    <button
+      disabled={disabled}
+      onClick={handleCancel}
+    >
+      Cancelar
+    </button>
+  );
+}

--- a/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -10,6 +10,7 @@ import Icon from "../../components/admin/Icon";
 import { ICONS } from "../../helpers/admin/icons";
 import { fmt, fmtDate, fmtDateTime, } from "../../helpers/admin/formatters";
 import { TABS } from "../../helpers/admin/tabs";
+import ReservationActions from "../../components/admin/ReservationActions";
 
 export default function AdminDashboard() {
   const [tab, setTab] = useState("stats");
@@ -140,6 +141,23 @@ export default function AdminDashboard() {
       label: "Creada",
       render: (r) =>
         fmtDate(r.createdAt),
+    },
+
+    {
+      key: "actions",
+      label: "Acciones",
+      render: (r) => (
+        <ReservationActions
+          reservation={r}
+          reloadReservations={() =>
+            load(
+              "reservations",
+              getAllReservations,
+              setReservations
+            )
+          }
+        />
+      ),
     },
   ];
 


### PR DESCRIPTION
En este PR se implementan acciones administrativas para cancelación de reservas.
## Cambios realizados

- Se agregó consumo del endpoint admin para cancelar reservas
- Se creó componente reutilizable ReservationActions
- Se añadió columna de acciones en tabla de reservas
- Se implementaron confirmaciones con SweetAlert
- Se agregó actualización automática de tabla después de cancelar
- Se bloquearon acciones para reservas canceladas o expiradas

## Mejoras
- Arquitectura desacoplada mediante componentes reutilizables
- AdminTable permanece genérico y escalable
- Preparado para futuras acciones administrativas

-------------------------------------------------------------------------------

close #85  