### PR TITLE
feat: mostrar fecha de registro en la tabla administrativa de usuarios

### DIFF
--- a/src/components/admin/columns/userColumns.jsx
+++ b/src/components/admin/columns/userColumns.jsx
@@ -1,6 +1,7 @@
 import Badge from "../ui/Badge";
 import { idColumn } from "../../../helpers/admin/tableColumns";
 import RoleBadge from "../ui/RoleBadge";
+import { fmtDate } from "../../../helpers/admin/formatters";
 
 export const userColumns = [
 
@@ -35,5 +36,11 @@ export const userColumns = [
         inactiveText="Inactivo"
       />
     ),
+  },
+
+  {
+    key: "createdAt",
+    label: "Fecha registro",
+    render: (u) => fmtDate(u.createdAt),
   },
 ];


### PR DESCRIPTION
En este PR se implemento la visualizacion de la fecha de creación de cada usuario dentro del dashboard administrativo.

**Cambios**

- La columna aparece en el listado.
- La fecha se muestra formateada.
- No se muestran fechas inválidas.
- Los usuarios sin fecha muestran: "—"