### PR TITLE
feat: implementar creación de administradores desde el panel

### DIFF
--- a/src/api/adminApi.js
+++ b/src/api/adminApi.js
@@ -38,3 +38,8 @@ export const getUsers = async () => {
   const res = await API.get("/admin/users");
   return res.data;
 };
+
+export const createAdmin = async (userData) => {
+  const res = await API.post("/admin/users/admin", userData);
+  return res.data;
+} 

--- a/src/components/admin/filters/TableFilters.jsx
+++ b/src/components/admin/filters/TableFilters.jsx
@@ -26,6 +26,7 @@ export default function TableFilters({
   refreshing,
 
   onCreate,
+  createLabel,
   onExport,
   exportLabel = "Exportar CSV",
 
@@ -246,7 +247,8 @@ export default function TableFilters({
                 border: "1px solid #bfdbfe",
               }}
             >
-              <Plus size={16} /> Nueva Sala
+              <Plus size={16} />
+              {createLabel}
             </button>
           )}
 

--- a/src/components/admin/tables/RoomsTable.jsx
+++ b/src/components/admin/tables/RoomsTable.jsx
@@ -102,6 +102,7 @@ export default function RoomsTable({
           statuses: STATUS_OPTIONS,
           onRefresh: refresh,
           onCreate: handleCreateRoom,
+          createLabel: "Crear sala",
           refreshing,
           exportLabel: "Exportar CSV",
           Icon,

--- a/src/components/admin/tables/UsersTable.jsx
+++ b/src/components/admin/tables/UsersTable.jsx
@@ -3,6 +3,7 @@ import DataTable from "./DataTable";
 import AdminSection from "./AdminSection";
 import useRefresh from "../hooks/useRefresh";
 import useTableFilters from "../hooks/useTableFilters";
+import CreateAdminModal from "../users/CreateAdminModal";
 
 const ROLE_OPTIONS = [
   {
@@ -60,6 +61,11 @@ export default function UsersTable({
     setRoleFilter] =
     useState("ALL");
 
+  const [
+    showCreateModal,
+    setShowCreateModal,
+  ] = useState(false);
+
   const filtered = useMemo(() => {
     return users.filter((user) => {
       const term =
@@ -90,6 +96,12 @@ export default function UsersTable({
     });
   }, [users, search, roleFilter, statusFilter]);
 
+  //handler
+  const handleCreateAdmin =
+    () => {
+      setShowCreateModal(true);
+    };
+
   return (
     <div>
       <AdminSection
@@ -112,6 +124,9 @@ export default function UsersTable({
           onRefresh: refresh,
           refreshing,
 
+          onCreate: handleCreateAdmin,
+          createLabel: "Crear administrador",        
+
           Icon,
           ICONS,
         }}
@@ -122,6 +137,11 @@ export default function UsersTable({
           rows: filtered,
           emptyMsg: "No hay usuarios registrados",
         }}
+      />
+      <CreateAdminModal
+        open={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        reloadUsers={reloadUsers}
       />
     </div>
   );

--- a/src/components/admin/users/AdminForm.jsx
+++ b/src/components/admin/users/AdminForm.jsx
@@ -1,0 +1,333 @@
+import { useState } from "react";
+import {
+  User, Mail, Lock, Eye, EyeOff, Building2,
+  Users, MapPin, List, Camera, Loader2, Plus,
+} from "lucide-react";
+
+function Field({
+  label,
+  error,
+  children,
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+      }}
+    >
+      <label
+        style={{
+          fontSize: 11,
+          fontWeight: 500,
+          textTransform: "uppercase",
+          letterSpacing: ".5px",
+          color: "#9ca3af",
+        }}
+      >
+        {label}
+      </label>
+
+      {children}
+
+      {error && (
+        <p
+          style={{
+            fontSize: 11,
+            color: "#ef4444",
+            margin: 0,
+          }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+const inputStyle = {
+  height: 36,
+  width: "100%",
+  boxSizing: "border-box",
+  padding: "0 10px 0 32px",
+  fontSize: 13,
+  background: "#f9fafb",
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+};
+
+function IconInput({
+  icon: Icon,
+  ...props
+}) {
+  return (
+    <div
+      style={{
+        position: "relative",
+      }}
+    >
+      <Icon
+        size={14}
+        style={{
+          position: "absolute",
+          left: 10,
+          top: "50%",
+          transform: "translateY(-50%)",
+          color: "#9ca3af",
+        }}
+      />
+
+      <input
+        {...props}
+        style={inputStyle}
+      />
+    </div>
+  );
+}
+
+export default function UserForm({
+  onSubmit,
+  loading,
+}) {
+  const [form, setForm] =
+    useState({
+      username: "",
+      email: "",
+      password: "",
+    });
+
+  const [errors, setErrors] =
+    useState({});
+
+  const [showPassword, setShowPassword] =
+    useState(false);
+
+  const emailRegex =
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const strongPasswordRegex =
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&._-])[A-Za-z\d@$!%*?&._-]{8,}$/;
+
+  const set = (key, value) => {
+    setForm((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+
+    setErrors((prev) => ({
+      ...prev,
+      [key]: undefined,
+    }));
+  };
+
+  const validateField = (key, value) => {
+    setErrors((prev) => {
+      const next = { ...prev };
+
+      if (key === "username") {
+        if (value.length < 3) {
+          next.username = "Mínimo 3 caracteres";
+        } else {
+          delete next.username;
+        }
+      }
+
+      if (key === "email") {
+        if (!emailRegex.test(value)) {
+          next.email = "Ingresa un email válido";
+        } else {
+          delete next.email;
+        }
+      }
+
+      if (key === "password") {
+        if (!strongPasswordRegex.test(value)) {
+          next.password =
+            "Mínimo 8 caracteres, mayúscula, minúscula, número y símbolo";
+        } else {
+          delete next.password;
+        }
+      }
+
+      return next;
+    });
+  };
+
+  const submit = (e) => {
+    e.preventDefault();
+
+    const errs = validate();
+
+    if (
+      Object.keys(errs).length > 0
+    ) {
+      setErrors(errs);
+      return;
+    }
+
+    onSubmit(form);
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <Field
+        label="Usuario"
+        error={errors.username}
+      >
+        <IconInput
+          icon={User}
+          value={form.username}
+          onChange={(e) =>
+            set(
+              "username",
+              e.target.value
+            )
+          }
+        />
+      </Field>
+
+      <Field
+        label="Correo"
+        error={errors.email}
+      >
+        <IconInput
+          icon={Mail}
+          type="email"
+          value={form.email}
+          onChange={(e) => {
+            set("email", e.target.value);
+            validateField("email", e.target.value);
+          }}
+        />
+      </Field>
+
+      <Field
+        label="Contraseña"
+        error={errors.password}
+      >
+        <div
+          style={{
+            position: "relative",
+            width: "100%",
+          }}
+        >
+          <Lock
+            size={14}
+            style={{
+              position: "absolute",
+              left: 10,
+              top: "50%",
+              transform: "translateY(-50%)",
+              color: "#9ca3af",
+              zIndex: 1,
+            }}
+          />
+
+          <input
+            type={showPassword ? "text" : "password"}
+            value={form.password}
+            onChange={(e) => {
+              set("password", e.target.value);
+              validateField("password", e.target.value);
+            }}
+            style={{
+              ...inputStyle,
+              paddingLeft: 32,
+              paddingRight: 40,
+            }}
+          />
+
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            style={{
+              position: "absolute",
+              right: 10,
+              top: "50%",
+              transform: "translateY(-50%)",
+              border: "none",
+              background: "transparent",
+              padding: 0,
+              margin: 0,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#9ca3af",
+              zIndex: 1,
+            }}
+          >
+            {showPassword ? (
+              <EyeOff size={16} />
+            ) : (
+              <Eye size={16} />
+            )}
+          </button>
+        </div>
+      </Field>
+
+      <div
+        style={{
+          borderTop:
+            "1px solid #f3f4f6",
+          paddingTop: 8,
+          display: "flex",
+          justifyContent: "flex-end",
+        }}
+      >
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            height: 34,
+            padding: "0 16px",
+            border: "none",
+            borderRadius: 8,
+            background:
+              loading
+                ? "#93c5fd"
+                : "#1d4ed8",
+            color: "#fff",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+          }}
+        >
+          {loading ? (
+            <Loader2
+              size={14}
+              style={{
+                animation:
+                  "spin 1s linear infinite",
+              }}
+            />
+          ) : (
+            <Plus size={14} />
+          )}
+
+          {loading
+            ? "Guardando..."
+            : "Crear administrador"}
+        </button>
+      </div>
+
+      <style>
+        {`
+          @keyframes spin {
+            to {
+              transform: rotate(360deg);
+            }
+          }
+        `}
+      </style>
+    </form>
+  );
+}

--- a/src/components/admin/users/CreateAdminModal.jsx
+++ b/src/components/admin/users/CreateAdminModal.jsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import Swal from "sweetalert2";
+
+import Modal from "../ui/Modal";
+import AdminForm from "./AdminForm";
+
+import { createAdmin } from "../../../api/adminApi";
+
+export default function CreateAdminModal({
+  open,
+  onClose,
+  reloadUsers,
+}) {
+  const [loading, setLoading] =
+    useState(false);
+
+  const handleCreate =
+    async (userData) => {
+
+      try {
+        setLoading(true);
+
+        await createAdmin(
+          userData
+        );
+
+        await reloadUsers();
+
+        Swal.fire({
+          icon: "success",
+          title:
+            "Administrador creado",
+          timer: 1500,
+          showConfirmButton:
+            false,
+        });
+
+        onClose();
+
+      } catch (error) {
+
+        const msg =
+          error.response?.data
+            ?.message ||
+          "No fue posible crear el administrador";
+
+        Swal.fire({
+          icon: "error",
+          title: "Error",
+          text: msg,
+        });
+
+      } finally {
+        setLoading(false);
+      }
+    };
+
+  return (
+    <Modal
+      title="Crear administrador"
+      open={open}
+      onClose={onClose}
+    >
+      <AdminForm
+        onSubmit={handleCreate}
+        loading={loading}
+      />
+    </Modal>
+  );
+}


### PR DESCRIPTION
En este PR se incorporó la interfaz para creación de administradores dentro del panel administrativo y se mejoró la reutilización de componentes compartidos.

## Cambios realizados

### Gestión de usuarios

* Creación de modal para registro de administradores.
* Creación de formulario reutilizable `UserForm`.
* Integración con endpoint de creación de administradores.
* Recarga automática del listado tras crear un administrador.

### Validaciones

* Validación de correo electrónico.
* Validación de contraseña segura:

  * Mínimo 8 caracteres.
  * Una letra mayúscula.
  * Una letra minúscula.
  * Un número.
  * Un carácter especial.
* Mensajes de error dinámicos que desaparecen al corregir los datos.

### Experiencia de usuario

* Opción para mostrar y ocultar contraseña.
* Icono integrado dentro del campo de contraseña.
* Indicadores visuales de carga durante el envío.

### Componentes compartidos

* Se agregó soporte para etiquetas personalizadas en botones de creación mediante `createLabel`.
* Ahora el componente reutilizable permite mostrar:

  * Nueva sala
  * Nuevo administrador
  * Futuras entidades administrativas

Los administradores pueden crear nuevas cuentas administrativas desde el panel con validaciones visuales, mejor experiencia de usuario y reutilización de componentes existentes.

--------
closes #107 