### PR TITLE
feat(admin): agregar activación y desactivación de usuarios

### DIFF
--- a/src/api/adminApi.js
+++ b/src/api/adminApi.js
@@ -43,3 +43,8 @@ export const createAdmin = async (userData) => {
   const res = await API.post("/admin/users/admin", userData);
   return res.data;
 } 
+
+export const updateUserStatus = async (userId,enabled) => {
+  const res = await API.patch( `/admin/users/${userId}/status`, { enabled });
+  return res.data;
+};

--- a/src/components/admin/columns/userColumns.jsx
+++ b/src/components/admin/columns/userColumns.jsx
@@ -2,8 +2,9 @@ import Badge from "../ui/Badge";
 import { idColumn } from "../../../helpers/admin/tableColumns";
 import RoleBadge from "../ui/RoleBadge";
 import { fmtDate } from "../../../helpers/admin/formatters";
+import UserActions from "../users/UserActions";
 
-export const userColumns = [
+export const userColumns = (handleToggleStatus) => [
 
   idColumn,
 
@@ -42,5 +43,18 @@ export const userColumns = [
     key: "createdAt",
     label: "Fecha registro",
     render: (u) => fmtDate(u.createdAt),
+  },
+
+  {
+    key: "actions",
+    label: "Acciones",
+    render: (u) => (
+      <UserActions
+        user={u}
+        onToggleStatus={
+          handleToggleStatus
+        }
+      />
+    ),
   },
 ];

--- a/src/components/admin/tables/UsersTable.jsx
+++ b/src/components/admin/tables/UsersTable.jsx
@@ -125,7 +125,7 @@ export default function UsersTable({
           refreshing,
 
           onCreate: handleCreateAdmin,
-          createLabel: "Crear administrador",        
+          createLabel: "Crear administrador",
 
           Icon,
           ICONS,

--- a/src/components/admin/users/UserActions.jsx
+++ b/src/components/admin/users/UserActions.jsx
@@ -1,0 +1,67 @@
+import Swal from "sweetalert2";
+
+export default function UserActions({
+  user,
+  onToggleStatus,
+}) {
+  const handleClick = async () => {
+    const activating = !user.enabled;
+
+    const result = await Swal.fire({
+      icon: activating ? "question" : "warning",
+      title: activating
+        ? "Activar usuario"
+        : "Desactivar usuario",
+      text: activating
+        ? "El usuario podrá iniciar sesión nuevamente."
+        : "El usuario no podrá iniciar sesión hasta ser activado nuevamente.",
+      showCancelButton: true,
+      confirmButtonText: activating
+        ? "Activar"
+        : "Desactivar",
+      cancelButtonText: "Cancelar",
+      confirmButtonColor: activating
+        ? "#10b981"
+        : "#ef4444",
+    });
+
+    if (result.isConfirmed) {
+      onToggleStatus(user);
+    }
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      style={{
+        width: 42,
+        height: 22,
+        borderRadius: 999,
+        background: user.enabled
+          ? "#10b981"
+          : "#d1d5db",
+        position: "relative",
+        cursor: "pointer",
+        transition: ".2s",
+      }}
+    >
+      <div
+        style={{
+          width: 18,
+          height: 18,
+          borderRadius: "50%",
+          background: "#fff",
+          position: "absolute",
+          top: 2,
+          left: 2,
+          transform: user.enabled
+            ? "translateX(20px)"
+            : "translateX(0)",
+          transition: ".2s",
+          boxShadow:
+            "0 1px 3px rgba(0,0,0,.15)",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import Swal from "sweetalert2";
 import AdminHeader from "../../components/admin/layout/AdminHeader";
 import AdminSidebar from "../../components/admin/layout/AdminSidebar";
 import DashboardStats from "../../components/admin/stats/DashboardStats";
@@ -26,6 +27,7 @@ import { userColumns } from "../../components/admin/columns/userColumns";
 import EditRoomModal from "../../components/admin/rooms/EditRoomModal";
 import DeleteRoomModal from "../../components/admin/rooms/DeleteRoomModal";
 
+import { updateUserStatus } from "../../api/adminApi";
 
 export default function AdminDashboard() {
 
@@ -87,6 +89,31 @@ export default function AdminDashboard() {
     setDeletingRoom(room);
   };
 
+  // User handlers
+  const handleToggleStatus = async (user) => {
+    try {
+      await updateUserStatus(user.id, !user.enabled);
+
+      await reloadUsers();
+
+      Swal.fire({
+        icon: "success",
+        title: "Éxito",
+        text: "Estado actualizado correctamente",
+        timer: 1500,
+        showConfirmButton: false,
+      });
+    } catch (error) {
+      Swal.fire({
+        icon: "error",
+        title: "Error",
+        text:
+          error.response?.data?.message ||
+          "No fue posible actualizar el estado",
+      });
+    }
+  };
+
   // ─── useMemo ──────────────────
   const resCols = useMemo(
     () => reservationColumns(reloadReservations),
@@ -105,6 +132,11 @@ export default function AdminDashboard() {
         handleDeleteRoom
       ),
     [handleEditRoom, handleDeleteRoom]
+  );
+
+  const userColsMemo = useMemo(
+    () => userColumns(handleToggleStatus),
+    [handleToggleStatus]
   );
 
   return (
@@ -143,7 +175,7 @@ export default function AdminDashboard() {
           style={{ flex: 1, padding: "28px 32px", maxWidth: 1100, }}
         >
 
-        {/* Tables */}
+          {/* Tables */}
 
           {/* Stats */}
           {tab === "stats" && (
@@ -203,7 +235,7 @@ export default function AdminDashboard() {
               loading={usersLoading}
               error={usersError}
               reloadUsers={reloadUsers}
-              userCols={userColumns}
+              userCols={userColumns(handleToggleStatus)}
               Icon={Icon}
               ICONS={ICONS}
             />


### PR DESCRIPTION
Se implementó la funcionalidad para que los administradores puedan activar o desactivar cuentas de usuario desde el panel administrativo.

* Se agregó una nueva acción en la tabla de usuarios para activar o desactivar cuentas.
* Se implementó un switch visual para representar el estado actual del usuario.
* Se agregó confirmación mediante SweetAlert antes de realizar cambios.
* Se muestran mensajes de éxito y error según el resultado de la operación.
* Se recarga automáticamente el listado de usuarios después de actualizar el estado.

## Notas

Se identificó una posible mejora relacionada con la activación de usuarios que aún no han verificado su correo electrónico. Esta validación no forma parte del alcance de este PR y será tratada en un issue independiente.

-----------
closes #113 