### PR TITLE
 mostrar estado de verificación de correo en tabla

### DIFF
--- a/src/components/admin/columns/userColumns.jsx
+++ b/src/components/admin/columns/userColumns.jsx
@@ -28,6 +28,18 @@ export const userColumns = (handleToggleStatus) => [
   },
 
   {
+    key: "emailVerified",
+    label: "Verificación",
+    render: (u) => (
+      <Badge
+        active={u.emailVerified}
+        activeText="Verificado"
+        inactiveText="Pendiente"
+      />
+    ),
+  },
+  
+  {
     key: "enabled",
     label: "Estado",
     render: (u) => (


### PR DESCRIPTION
En este PR se agregó la visualización del estado de verificación de correo en la tabla administrativa de usuarios.

## Cambios realizados

- Se añadió el campo emailVerified al modelo de usuario.
- Se agregó una nueva columna "Verificación".
- Se muestran badges para indicar si el correo está:
  - Verificado
  - Pendiente

## Resultado

Permite distinguir claramente entre la verificación del correo electrónico y el estado administrativo de la cuenta.

-----------------------
closes #115 