### PR TITLE
feat: bloquear desactivación de cuenta propia en panel administrativo

### DIFF
--- a/src/components/admin/columns/userColumns.jsx
+++ b/src/components/admin/columns/userColumns.jsx
@@ -4,7 +4,7 @@ import RoleBadge from "../ui/RoleBadge";
 import { fmtDate } from "../../../helpers/admin/formatters";
 import UserActions from "../users/UserActions";
 
-export const userColumns = (handleToggleStatus) => [
+export const userColumns = (handleToggleStatus, isCurrentUsername,) => [
 
   idColumn,
 
@@ -65,6 +65,9 @@ export const userColumns = (handleToggleStatus) => [
         user={u}
         onToggleStatus={
           handleToggleStatus
+        }
+        isCurrentUsername= {
+          u.username === isCurrentUsername
         }
       />
     ),

--- a/src/components/admin/users/UserActions.jsx
+++ b/src/components/admin/users/UserActions.jsx
@@ -3,8 +3,19 @@ import Swal from "sweetalert2";
 export default function UserActions({
   user,
   onToggleStatus,
+  isCurrentUsername,
 }) {
   const handleClick = async () => {
+    if (isCurrentUsername) {
+      Swal.fire({
+        icon: "info",
+        title: "Acción no permitida",
+        text: "No puedes desactivar tu propia cuenta.",
+      });
+
+      return;
+    }
+
     const activating = !user.enabled;
 
     const result = await Swal.fire({
@@ -41,8 +52,11 @@ export default function UserActions({
           ? "#10b981"
           : "#d1d5db",
         position: "relative",
-        cursor: "pointer",
+        cursor: isCurrentUsername
+          ? "not-allowed"
+          : "pointer",
         transition: ".2s",
+        opacity: isCurrentUsername ? 0.6 : 1,
       }}
     >
       <div

--- a/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -139,6 +139,11 @@ export default function AdminDashboard() {
     [handleToggleStatus]
   );
 
+  // ------------UI------------
+  const isCurrentUsername =
+    localStorage.getItem("username") ||
+    sessionStorage.getItem("username");
+
   return (
 
     <div
@@ -235,7 +240,7 @@ export default function AdminDashboard() {
               loading={usersLoading}
               error={usersError}
               reloadUsers={reloadUsers}
-              userCols={userColumns(handleToggleStatus)}
+              userCols={userColumns(handleToggleStatus, isCurrentUsername)}
               Icon={Icon}
               ICONS={ICONS}
             />


### PR DESCRIPTION
En este PR se agregaron validaciones para evitar acciones no permitidas durante la administración de usuarios.


## Cambios

- Se deshabilitó el interruptor de estado para el administrador autenticado.
- Se agregó retroalimentación visual para la acción deshabilitada.
- Se reutilizó la configuración de columnas de usuario memorizadas.

Esto evita que los administradores deshabiliten accidentalmente su propia cuenta desde el panel de administración de usuarios.


--------------
closes #118 