### PR TITLE
feat: implementar cambio de roles de usuarios desde panel administrativo

### DIFF
--- a/src/api/adminApi.js
+++ b/src/api/adminApi.js
@@ -48,3 +48,8 @@ export const updateUserStatus = async (userId,enabled) => {
   const res = await API.patch( `/admin/users/${userId}/status`, { enabled });
   return res.data;
 };
+
+export const updateUserRole = async (userId, role) => {
+  const res = await API.patch(`/admin/users/${userId}/role`, { role });
+  return res.data;
+}

--- a/src/components/admin/columns/userColumns.jsx
+++ b/src/components/admin/columns/userColumns.jsx
@@ -3,8 +3,9 @@ import { idColumn } from "../../../helpers/admin/tableColumns";
 import RoleBadge from "../ui/RoleBadge";
 import { fmtDate } from "../../../helpers/admin/formatters";
 import UserActions from "../users/UserActions";
+import UserStatusToggle from "../users/UserStatusToggle";
 
-export const userColumns = (handleToggleStatus, isCurrentUsername,) => [
+export const userColumns = (onToggleStatus, onChangeRole, isCurrentUsername) => [
 
   idColumn,
 
@@ -43,11 +44,24 @@ export const userColumns = (handleToggleStatus, isCurrentUsername,) => [
     key: "enabled",
     label: "Estado",
     render: (u) => (
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+      }}>
       <Badge
         active={u.enabled}
         activeText="Activo"
         inactiveText="Inactivo"
       />
+      <UserStatusToggle
+        user={u}
+        onToggleStatus={onToggleStatus}
+        isCurrentUsername={
+          u.username === isCurrentUsername
+        }
+      />
+      </div>
     ),
   },
 
@@ -61,15 +75,22 @@ export const userColumns = (handleToggleStatus, isCurrentUsername,) => [
     key: "actions",
     label: "Acciones",
     render: (u) => (
+      <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        height: 60,
+      }}
+    >
       <UserActions
         user={u}
-        onToggleStatus={
-          handleToggleStatus
-        }
+        onChangeRole={onChangeRole}
         isCurrentUsername= {
           u.username === isCurrentUsername
         }
       />
+      </div>
     ),
   },
 ];

--- a/src/components/admin/hooks/useUserActions.js
+++ b/src/components/admin/hooks/useUserActions.js
@@ -1,0 +1,82 @@
+import Swal from "sweetalert2";
+import { updateUserStatus, updateUserRole, } from "../../../api/adminApi";
+
+export default function useUserActions(
+  reloadUsers
+) {
+
+  const toggleStatus = async (user) => {
+
+    try {
+
+      await updateUserStatus(
+        user.id,
+        !user.enabled
+      );
+
+      await reloadUsers();
+
+      Swal.fire({
+        icon: "success",
+        title: "Éxito",
+        text: "Estado actualizado correctamente",
+        timer: 1500,
+        showConfirmButton: false,
+      });
+
+    } catch (error) {
+
+      Swal.fire({
+        icon: "error",
+        title: "Error",
+        text:
+          error.response?.data?.message ||
+          "No fue posible actualizar el estado",
+      });
+    }
+  };
+
+  const changeRole = async (user) => {
+
+    try {
+
+      const isAdmin =
+        user.roles.includes("ROLE_ADMIN");
+
+      const newRole =
+        isAdmin
+          ? "ROLE_USER"
+          : "ROLE_ADMIN";
+
+      await updateUserRole(
+        user.id,
+        newRole
+      );
+
+      await reloadUsers();
+
+      Swal.fire({
+        icon: "success",
+        title: "Éxito",
+        text: "Rol actualizado correctamente",
+        timer: 1500,
+        showConfirmButton: false,
+      });
+
+    } catch (error) {
+
+      Swal.fire({
+        icon: "error",
+        title: "Error",
+        text:
+          error.response?.data?.message ||
+          "No fue posible actualizar el rol",
+      });
+    }
+  };
+
+  return {
+    toggleStatus,
+    changeRole,
+  };
+}

--- a/src/components/admin/tables/AdminTable.jsx
+++ b/src/components/admin/tables/AdminTable.jsx
@@ -55,6 +55,8 @@ export default function AdminTable({
                     key={c.key}
                     style={{
                       padding: "11px 14px",
+                      verticalAlign: "middle",
+                      height: 60,
                     }}
                   >
                     {c.render

--- a/src/components/admin/users/UserActions.jsx
+++ b/src/components/admin/users/UserActions.jsx
@@ -2,80 +2,67 @@ import Swal from "sweetalert2";
 
 export default function UserActions({
   user,
-  onToggleStatus,
+  onChangeRole,
   isCurrentUsername,
 }) {
-  const handleClick = async () => {
+
+  const handleRoleChange = async () => {
+
     if (isCurrentUsername) {
       Swal.fire({
         icon: "info",
         title: "Acción no permitida",
-        text: "No puedes desactivar tu propia cuenta.",
+        text: "No puedes remover tus propios privilegios administrativos.",
       });
 
       return;
     }
 
-    const activating = !user.enabled;
+    const isAdmin =
+      user.roles.includes("ROLE_ADMIN");
 
     const result = await Swal.fire({
-      icon: activating ? "question" : "warning",
-      title: activating
-        ? "Activar usuario"
-        : "Desactivar usuario",
-      text: activating
-        ? "El usuario podrá iniciar sesión nuevamente."
-        : "El usuario no podrá iniciar sesión hasta ser activado nuevamente.",
+      icon: "question",
+      title: isAdmin
+        ? "Remover privilegios administrativos"
+        : "Convertir en administrador",
+      text: isAdmin
+        ? "¿Desea remover privilegios administrativos de este usuario?"
+        : "¿Desea convertir este usuario en administrador?",
       showCancelButton: true,
-      confirmButtonText: activating
-        ? "Activar"
-        : "Desactivar",
+      confirmButtonText: "Confirmar",
       cancelButtonText: "Cancelar",
-      confirmButtonColor: activating
-        ? "#10b981"
-        : "#ef4444",
     });
 
     if (result.isConfirmed) {
-      onToggleStatus(user);
+      onChangeRole(user);
     }
   };
 
   return (
-    <div
-      onClick={handleClick}
+    <button
+      type="button"
+      onClick={handleRoleChange}
+      disabled={isCurrentUsername}
       style={{
-        width: 42,
-        height: 22,
+        height: 28,
+        border: "1px solid #4338ca",
         borderRadius: 999,
-        background: user.enabled
-          ? "#10b981"
-          : "#d1d5db",
-        position: "relative",
+        background: "#eef2ff",
+        color: "#4338ca",
+        padding: "0 12px",
+        fontSize: 12,
+        fontWeight: 600,
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
         cursor: isCurrentUsername
           ? "not-allowed"
           : "pointer",
-        transition: ".2s",
         opacity: isCurrentUsername ? 0.6 : 1,
       }}
     >
-      <div
-        style={{
-          width: 18,
-          height: 18,
-          borderRadius: "50%",
-          background: "#fff",
-          position: "absolute",
-          top: 2,
-          left: 2,
-          transform: user.enabled
-            ? "translateX(20px)"
-            : "translateX(0)",
-          transition: ".2s",
-          boxShadow:
-            "0 1px 3px rgba(0,0,0,.15)",
-        }}
-      />
-    </div>
+      Cambiar rol
+    </button>
   );
 }

--- a/src/components/admin/users/UserStatusToggle.jsx
+++ b/src/components/admin/users/UserStatusToggle.jsx
@@ -1,0 +1,87 @@
+import Swal from "sweetalert2";
+
+export default function UserStatusToggle({
+  user,
+  onToggleStatus,
+  isCurrentUsername,
+}) {
+
+  const handleClick = async () => {
+
+    if (isCurrentUsername) {
+      Swal.fire({
+        icon: "info",
+        title: "Acción no permitida",
+        text: "No puedes desactivar tu propia cuenta.",
+      });
+
+      return;
+    }
+
+    const activating = !user.enabled;
+
+    const result = await Swal.fire({
+      icon: activating
+        ? "question"
+        : "warning",
+      title: activating
+        ? "Activar usuario"
+        : "Desactivar usuario",
+      text: activating
+        ? "El usuario podrá iniciar sesión nuevamente."
+        : "El usuario no podrá iniciar sesión hasta ser activado nuevamente.",
+      showCancelButton: true,
+      confirmButtonText: activating
+        ? "Activar"
+        : "Desactivar",
+      cancelButtonText: "Cancelar",
+      confirmButtonColor: activating
+        ? "#10b981"
+        : "#ef4444",
+    });
+
+    if (result.isConfirmed) {
+      onToggleStatus(user);
+    }
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      style={{
+        width: 42,
+        height: 18,
+        borderRadius: 999,
+        background: user.enabled
+          ? "#10b981"
+          : "#d1d5db",
+        position: "relative",
+        cursor: isCurrentUsername
+          ? "not-allowed"
+          : "pointer",
+        transition: ".2s",
+        opacity: isCurrentUsername
+          ? 0.6
+          : 1,
+      }}
+    >
+      <div
+        style={{
+          width: 14,
+          height: 14,
+          borderRadius: "50%",
+          background: "#fff",
+          position: "absolute",
+          top: 2,
+          left: 2,
+          transform: user.enabled
+            ? "translateX(24px)"
+            : "translateX(0)",
+          transition: ".2s",
+          boxShadow:
+            "0 1px 3px rgba(0,0,0,.15)",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -27,7 +27,7 @@ import { userColumns } from "../../components/admin/columns/userColumns";
 import EditRoomModal from "../../components/admin/rooms/EditRoomModal";
 import DeleteRoomModal from "../../components/admin/rooms/DeleteRoomModal";
 
-import { updateUserStatus } from "../../api/adminApi";
+import useUserActions from "../../components/admin/hooks/useUserActions";
 
 export default function AdminDashboard() {
 
@@ -90,29 +90,9 @@ export default function AdminDashboard() {
   };
 
   // User handlers
-  const handleToggleStatus = async (user) => {
-    try {
-      await updateUserStatus(user.id, !user.enabled);
-
-      await reloadUsers();
-
-      Swal.fire({
-        icon: "success",
-        title: "Éxito",
-        text: "Estado actualizado correctamente",
-        timer: 1500,
-        showConfirmButton: false,
-      });
-    } catch (error) {
-      Swal.fire({
-        icon: "error",
-        title: "Error",
-        text:
-          error.response?.data?.message ||
-          "No fue posible actualizar el estado",
-      });
-    }
-  };
+  const { toggleStatus, changeRole } = useUserActions(
+    reloadUsers
+  );
 
   // ─── useMemo ──────────────────
   const resCols = useMemo(
@@ -132,11 +112,6 @@ export default function AdminDashboard() {
         handleDeleteRoom
       ),
     [handleEditRoom, handleDeleteRoom]
-  );
-
-  const userColsMemo = useMemo(
-    () => userColumns(handleToggleStatus),
-    [handleToggleStatus]
   );
 
   // ------------UI------------
@@ -240,7 +215,7 @@ export default function AdminDashboard() {
               loading={usersLoading}
               error={usersError}
               reloadUsers={reloadUsers}
-              userCols={userColumns(handleToggleStatus, isCurrentUsername)}
+              userCols={userColumns(toggleStatus, changeRole, isCurrentUsername)}
               Icon={Icon}
               ICONS={ICONS}
             />


### PR DESCRIPTION
En este PR se agregó la funcionalidad para cambiar roles de usuarios desde el panel administrativo, permitiendo promover usuarios a administradores o remover privilegios administrativos según corresponda.

## Cambios realizados

### API
- Se agregó la función `updateUserRole` para consumir el endpoint de actualización de roles.

### Gestión de usuarios
- Se creó el hook `useUserActions` para centralizar las acciones administrativas sobre usuarios.
- Se separó la lógica de cambio de estado y cambio de rol.

### Tabla de usuarios
- Se incorporó un control visual independiente para activar/desactivar usuarios.
- Se agregó una nueva acción para cambiar el rol de un usuario.

### Experiencia de usuario
- Se agregaron modales de confirmación antes de modificar roles.
- Se muestran mensajes de éxito y error según el resultado de la operación.
- Se impide que un administrador modifique sus propios privilegios administrativos.

### Refactorización
- Se creó el componente `UserStatusToggle`.
- Se simplificó el componente `UserActions`.
- Se movió la lógica de acciones de usuario fuera de `AdminDashboard`.

## Resultado

Los administradores ahora pueden gestionar roles directamente desde el listado de usuarios de forma segura, manteniendo protegida su propia cuenta frente a cambios accidentales de privilegios.

------
closes #120 