### PR TITLE
refactor: mover estilos de Badge a CSS

### DIFF
--- a/src/components/admin/ui/Badge.jsx
+++ b/src/components/admin/ui/Badge.jsx
@@ -1,3 +1,5 @@
+import "./styles/Badge.css";
+
 export default function Badge({
   active,
   activeText,
@@ -5,18 +7,10 @@ export default function Badge({
 }) {
   return (
     <span
-      style={{
-        padding: "4px 10px",
-        borderRadius: 999,
-        fontSize: 12,
-        fontWeight: 600,
-        background: active
-          ? "#dcfce7"
-          : "#fee2e2",
-        color: active
-          ? "#166534"
-          : "#991b1b",
-      }}
+      className={`badge ${active
+          ? "badge--active"
+          : "badge--inactive"
+        }`}
     >
       {active
         ? activeText

--- a/src/components/admin/ui/styles/Badge.css
+++ b/src/components/admin/ui/styles/Badge.css
@@ -1,0 +1,16 @@
+.badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge--active {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge--inactive {
+  background: #fee2e2;
+  color: #991b1b;
+}


### PR DESCRIPTION
Se extrajeron los estilos de Badge a un archivo CSS dedicado.

## Cambios realizados

* Se creó Badge.css.
* Se eliminaron estilos inline.
* Se agregaron modificadores para estados activo e inactivo.

## Beneficios

* Código más limpio.
* Mejor reutilización de estilos.
* Consistencia con otros componentes del panel administrativo.
---------
closes #127 