### PR TITLE
refactor: mover estilos de StatusPill a CSS

### DIFF
--- a/src/components/admin/ui/StatusPill.jsx
+++ b/src/components/admin/ui/StatusPill.jsx
@@ -1,38 +1,33 @@
+import "./styles/StatusPill.css";
+
 const STATUS_CONFIG = {
   PENDING: {
-    bg: "#fef3c7",
-    color: "#d97706",
+    className: "status-pill--pending",
     label: "Pendiente",
   },
   PAID: {
-    bg: "#dcfce7",
-    color: "#16a34a",
+    className: "status-pill--paid",
     label: "Pagado",
   },
   CANCELLED: {
-    bg: "#fee2e2",
-    color: "#dc2626",
+    className: "status-pill--cancelled",
     label: "Cancelado",
   },
 };
 
-export default function StatusPill({ status }) {
-  const config = STATUS_CONFIG[status] || {
-    bg: "#f3f4f6",
-    color: "#6b7280",
-    label: status,
-  };
+export default function StatusPill({
+  status,
+}) {
+  const config =
+    STATUS_CONFIG[status] || {
+      className:
+        "status-pill--default",
+      label: status,
+    };
 
   return (
     <span
-      style={{
-        background: config.bg,
-        color: config.color,
-        padding: "5px 10px",
-        borderRadius: 999,
-        fontSize: 12,
-        fontWeight: 600,
-      }}
+      className={`status-pill ${config.className}`}
     >
       {config.label}
     </span>

--- a/src/components/admin/ui/styles/StatusPill.css
+++ b/src/components/admin/ui/styles/StatusPill.css
@@ -1,0 +1,26 @@
+.status-pill {
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status-pill--pending {
+  background: #fef3c7;
+  color: #d97706;
+}
+
+.status-pill--paid {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.status-pill--cancelled {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.status-pill--default {
+  background: #f3f4f6;
+  color: #6b7280;
+}


### PR DESCRIPTION
Se movieron los estilos de StatusPill a un archivo CSS dedicado.

## Cambios realizados

* Se creó StatusPill.css.
* Se eliminaron estilos inline.
* Se mantuvieron los colores y estados visuales existentes.

## Beneficios

* Separación entre lógica y presentación.
* Mejor mantenibilidad.
* Consistencia con el resto de componentes administrativos.

----------
closes #128 
