### PR TITLE
refactor: mover estilos de RoleBadge a CSS

### DIFF
--- a/src/components/admin/ui/RoleBadge.jsx
+++ b/src/components/admin/ui/RoleBadge.jsx
@@ -1,38 +1,31 @@
+import "./styles/RoleBadge.css";
+
+const ROLE_CONFIG = {
+  ROLE_ADMIN: {
+    text: "Administrador",
+    className: "role-badge--admin",
+  },
+
+  ROLE_USER: {
+    text: "Usuario",
+    className: "role-badge--user",
+  },
+};
+
 export default function RoleBadge({
   role,
 }) {
-  const config = {
-    ROLE_ADMIN: {
-      text: "Administrador",
-      background: "#ede9fe",
-      color: "#6d28d9",
-    },
-    ROLE_USER: {
-      text: "Usuario",
-      background: "#dbeafe",
-      color: "#1d4ed8",
-    },
-  };
-
-  const badge =
-    config[role] || {
+  const config =
+    ROLE_CONFIG[role] || {
       text: role,
-      background: "#f3f4f6",
-      color: "#374151",
+      className: "role-badge--default",
     };
 
   return (
     <span
-      style={{
-        padding: "4px 10px",
-        borderRadius: 999,
-        fontSize: 12,
-        fontWeight: 600,
-        background: badge.background,
-        color: badge.color,
-      }}
+      className={`role-badge ${config.className}`}
     >
-      {badge.text}
+      {config.text}
     </span>
   );
 }

--- a/src/components/admin/ui/styles/RoleBadge.css
+++ b/src/components/admin/ui/styles/RoleBadge.css
@@ -1,0 +1,21 @@
+.role-badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.role-badge--admin {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.role-badge--user {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.role-badge--default {
+  background: #f3f4f6;
+  color: #374151;
+}


### PR DESCRIPTION
Se movieron los estilos de RoleBadge a un archivo CSS dedicado.

## Cambios realizados

* Se creó RoleBadge.css.
* Se eliminaron estilos inline.
* Se mantuvieron los colores y estados visuales existentes.

## Beneficios

* Separación entre lógica y presentación.
* Mejor mantenibilidad.
* Consistencia con el resto de componentes administrativos.

----------
closes #133 
