### PR TITLE
refactor: mover estilos de Modal a CSS

### DIFF
--- a/src/components/admin/ui/Modal.jsx
+++ b/src/components/admin/ui/Modal.jsx
@@ -1,12 +1,24 @@
 import { X } from "lucide-react";
 import { useEffect } from "react";
+import "./styles/Modal.css";
 
 export default function Modal({ title, subtitle, open, onClose, children }) {
   useEffect(() => {
     if (!open) return;
-    const handler = (e) => { if (e.key === "Escape") onClose(); };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    const handler = (e) => {
+      if (e.key === "Escape")
+        onClose();
+    };
+    window.addEventListener(
+      "keydown",
+      handler
+    );
+
+    return () =>
+      window.removeEventListener(
+        "keydown",
+        handler
+      );
   }, [open, onClose]);
 
   if (!open) return null;
@@ -14,36 +26,27 @@ export default function Modal({ title, subtitle, open, onClose, children }) {
   return (
     <div
       onClick={onClose}
-      style={{
-        position: "fixed", inset: 0, zIndex: 50,
-        background: "rgba(0,0,0,.45)",
-        display: "flex", alignItems: "center", justifyContent: "center", padding: 16,
-      }}
+      className="modal-overlay"
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        style={{
-          width: "100%", maxWidth: 500,
-          background: "#fff", borderRadius: 12,
-          border: "1px solid #e5e7eb", overflow: "hidden",
-        }}
+        className="modal-container"
       >
         {/* header */}
-        <div style={{
-          display: "flex", alignItems: "center", justifyContent: "space-between",
-          padding: "10px 18px", borderBottom: "1px solid #f3f4f6",
-        }}>
+        <div className="modal-header">
           <div>
-            <p style={{ margin: 0, fontSize: 15, fontWeight: 600, color: "#1d4ed8" }}>{title}</p>
-            {subtitle && <p style={{ margin: "2px 0 0", fontSize: 12, color: "#9ca3af" }}>{subtitle}</p>}
+            <p className="modal-title">
+              {title}
+            </p>
+            {subtitle && (
+              <p className="modal-subtitle">
+                {subtitle}
+              </p>
+            )}
           </div>
           <button
             onClick={onClose}
-            style={{
-              borderRadius: 5, border: "none",
-              background: "#ef4444", color: "#fff", cursor: "pointer",
-              display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
-            }}
+            className="modal-close-btn"
           >
             {/* X inline */}
             < X size={12} color="#fff" />
@@ -51,7 +54,7 @@ export default function Modal({ title, subtitle, open, onClose, children }) {
         </div>
 
         {/* body — scrollable si el contenido crece */}
-        <div style={{ padding: "16px 18px", maxHeight: "75vh", overflowY: "auto" }}>
+        <div className="modal-body">
           {children}
         </div>
       </div>

--- a/src/components/admin/ui/styles/Modal.css
+++ b/src/components/admin/ui/styles/Modal.css
@@ -1,0 +1,75 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+
+  background: rgba(0, 0, 0, 0.45);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 16px;
+}
+
+.modal-container {
+  width: 100%;
+  max-width: 500px;
+
+  background: #fff;
+
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 10px 18px;
+
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.modal-title {
+  margin: 0;
+
+  font-size: 15px;
+  font-weight: 600;
+
+  color: #1d4ed8;
+}
+
+.modal-subtitle {
+  margin: 2px 0 0;
+
+  font-size: 12px;
+
+  color: #9ca3af;
+}
+
+.modal-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  flex-shrink: 0;
+
+  border: none;
+  border-radius: 5px;
+
+  background: #ef4444;
+  color: #fff;
+
+  cursor: pointer;
+}
+
+.modal-body {
+  padding: 16px 18px;
+
+  max-height: 75vh;
+  overflow-y: auto;
+}


### PR DESCRIPTION
Se movieron los estilos de Modal a un archivo CSS dedicado.

## Cambios realizados

* Se creó Modal.css.
* Se eliminaron estilos inline.
* Se mantuvieron los colores y estados visuales existentes.

## Beneficios

* Separación entre lógica y presentación.
* Mejor mantenibilidad.
* Consistencia con el resto de componentes administrativos.

----------
closes #129 