### PR TITLE
refactor: reutilizar useAdminResource en hooks administrativos

### DIFF
--- a/src/components/admin/hooks/useAdminResource.js
+++ b/src/components/admin/hooks/useAdminResource.js
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useState,
+  useCallback,
 } from "react";
 
 export default function
@@ -13,16 +14,14 @@ export default function
   const [data, setData] =
     useState([]);
 
-  const [loading,
-    setLoading] =
+  const [loading, setLoading] =
     useState(false);
 
-  const [error,
-    setError] =
+  const [error, setError] =
     useState("");
 
   const load =
-    async () => {
+    useCallback(async () => {
       try {
         setLoading(true);
         setError("");
@@ -38,13 +37,13 @@ export default function
       } finally {
         setLoading(false);
       }
-    };
+    }, [fetchFn, errorMessage]);
 
   useEffect(() => {
-    if (tab === currentTab) {
+    if (tab === currentTab && data.length === 0) {
       load();
     }
-  }, [tab, currentTab]);
+  }, [tab, currentTab, data.length, load]);
 
   return {
     data,

--- a/src/components/admin/hooks/usePayments.js
+++ b/src/components/admin/hooks/usePayments.js
@@ -1,52 +1,25 @@
-import { useEffect, useState }
-  from "react";
-
-import { getAllPayments }
-  from "../../../api/adminApi";
+import useAdminResource from "./useAdminResource";
+import { getAllPayments,} from "../../../api/adminApi";
 
 export default function usePayments(
   tab
 ) {
-  const [payments,setPayments] = useState([]);
-
-  const [loading, setLoading] = useState(false);
-
-  const [error, setError] = useState(null);
-
-  const loadPayments =
-    async () => {
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const data =
-        await getAllPayments();
-
-      setPayments(data);
-    } catch {
-      setError(
-        "Error al cargar pagos"
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (
-      tab === "payments" &&
-      payments.length === 0
-    ) {
-      loadPayments();
-    }
-  }, [tab]);
-
-  return {
-    payments,
+  const {
+    data,
     loading,
     error,
-    reloadPayments:
-      loadPayments,
+    reload,
+  } = useAdminResource(
+    tab,
+    "payments",
+    getAllPayments,
+    "Error al cargar pagos"
+  );
+
+  return {
+    payments: data,
+    loading,
+    error,
+    reloadPayments: reload,
   };
 }

--- a/src/components/admin/hooks/useReservations.js
+++ b/src/components/admin/hooks/useReservations.js
@@ -1,55 +1,27 @@
-import { useEffect, useState }
-  from "react";
+import useAdminResource from "./useAdminResource";
 
-import { getAllReservations }
-  from "../../../api/adminApi";
+import { getAllReservations,} from "../../../api/adminApi";
 
 export default function useReservations(
   tab
 ) {
-  const [reservations,
-    setReservations] = useState([]);
-
-  const [loading, setLoading] =
-    useState(false);
-
-  const [error, setError] =
-    useState(null);
-
-  const loadReservations =
-    async () => {
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const data =
-        await getAllReservations();
-
-      setReservations(data);
-    } catch {
-      setError(
-        "Error al cargar reservas"
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (
-      tab === "reservations" &&
-      reservations.length === 0
-    ) {
-      loadReservations();
-    }
-  }, [tab]);
+  const {
+    data,
+    loading,
+    error,
+    reload,
+  } = useAdminResource(
+    tab,
+    "reservations",
+    getAllReservations,
+    "Error al cargar reservas"
+  );
 
   return {
-    reservations,
+    reservations: data,
     loading,
     error,
     reloadReservations:
-      loadReservations,
+      reload,
   };
 }

--- a/src/components/admin/hooks/useRooms.js
+++ b/src/components/admin/hooks/useRooms.js
@@ -1,47 +1,25 @@
-import { useEffect, useState } from "react";
-
+import useAdminResource from "./useAdminResource";
 import { getAllRooms } from "../../../api/roomApi";
 
-export default function useRooms(tab) {
-  const [rooms, setRooms] = useState([]);
-
-  const [loading, setLoading] =
-    useState(false);
-
-  const [error, setError] =
-    useState(null);
-
-  const loadRooms = async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const data =
-        await getAllRooms();
-
-      setRooms(data);
-    } catch {
-      setError(
-        "Error al cargar salas"
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (
-      tab === "rooms" &&
-      rooms.length === 0
-    ) {
-      loadRooms();
-    }
-  }, [tab]);
-
-  return {
-    rooms,
+export default function useRooms(
+  tab
+) {
+  const {
+    data,
     loading,
     error,
-    reloadRooms: loadRooms,
+    reload,
+  } = useAdminResource(
+    tab,
+    "rooms",
+    getAllRooms,
+    "Error al cargar salas"
+  );
+
+  return {
+    rooms: data,
+    loading,
+    error,
+    reloadRooms: reload,
   };
 }

--- a/src/components/admin/hooks/useUsers.js
+++ b/src/components/admin/hooks/useUsers.js
@@ -1,44 +1,26 @@
-import { useEffect, useState, useCallback } from "react";
-import { getUsers } from "../../../api/adminApi";
+import useAdminResource from "./useAdminResource";
 
-export default function useUsers(tab) {
-  const [users, setUsers] = useState([]);
+import { getUsers, } from "../../../api/adminApi";
 
-  const [loading, setLoading] =
-    useState(false);
-
-  const [error, setError] =
-    useState("");
-
-  const loadUsers =
-    useCallback(async () => {
-      try {
-        setLoading(true);
-        setError("");
-
-        const data =
-          await getUsers();
-
-        setUsers(data);
-      } catch (err) {
-        setError(
-          "Error al cargar usuarios"
-        );
-      } finally {
-        setLoading(false);
-      }
-    }, []);
-
-  useEffect(() => {
-    if (tab === "users") {
-      loadUsers();
-    }
-  }, [tab, loadUsers]);
-
-  return {
-    users,
+export default function useUsers(
+  tab
+) {
+  const {
+    data,
     loading,
     error,
-    reloadUsers: loadUsers,
+    reload,
+  } = useAdminResource(
+    tab,
+    "users",
+    getUsers,
+    "Error al cargar usuarios"
+  );
+
+  return {
+    users: data,
+    loading,
+    error,
+    reloadUsers: reload,
   };
 }


### PR DESCRIPTION
Este PR centraliza la lógica común de carga de recursos administrativos utilizando `useAdminResource`, eliminando duplicación en los hooks de administración.

## Cambios realizados

### useAdminResource

* Se mejoró el hook para evitar recargas innecesarias al cambiar entre pestañas.
* Se incorporó `useCallback` para estabilizar la función de carga.
* Se mantiene la capacidad de recarga manual mediante `reload`.

### Hooks refactorizados

* `useRooms`
* `usePayments`
* `useReservations`
* `useUsers`

Todos los hooks ahora delegan la gestión de:

* carga inicial
* estado de loading
* manejo de errores
* recarga manual

en `useAdminResource`.

## Validación

* Las tablas continúan cargando correctamente.
* Los botones de refresco siguen funcionando mediante los métodos `reload`.
* No se observaron cambios funcionales ni visuales.
* La carga inicial ocurre una sola vez por pestaña, manteniendo el comportamiento previo.

--------
closes #137 