### PR TITLE
Refactor/migrar estilos inline a css

### DIFF
--- a/src/components/admin/columns/userColumns.jsx
+++ b/src/components/admin/columns/userColumns.jsx
@@ -4,6 +4,7 @@ import RoleBadge from "../ui/RoleBadge";
 import { fmtDate } from "../../../helpers/admin/formatters";
 import UserActions from "../users/UserActions";
 import UserStatusToggle from "../users/UserStatusToggle";
+import "../styles/admin-layout.css";
 
 export const userColumns = (onToggleStatus, onChangeRole, isCurrentUsername) => [
 
@@ -44,11 +45,7 @@ export const userColumns = (onToggleStatus, onChangeRole, isCurrentUsername) => 
     key: "enabled",
     label: "Estado",
     render: (u) => (
-      <div style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 10,
-      }}>
+      <div className="admin-inline-actions">
       <Badge
         active={u.enabled}
         activeText="Activo"
@@ -75,14 +72,7 @@ export const userColumns = (onToggleStatus, onChangeRole, isCurrentUsername) => 
     key: "actions",
     label: "Acciones",
     render: (u) => (
-      <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        height: 60,
-      }}
-    >
+      <div className="admin-center-cell">
       <UserActions
         user={u}
         onChangeRole={onChangeRole}

--- a/src/components/admin/layout/AdminHeader.css
+++ b/src/components/admin/layout/AdminHeader.css
@@ -1,0 +1,43 @@
+.admin-header {
+  background: #fff;
+  border-bottom: 1px solid #f0f0f0;
+  padding: 0 32px;
+  display: flex;
+  align-items: center;
+  height: 60px;
+  gap: 12px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.admin-header__logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: #111;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.admin-header__title {
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.2px;
+}
+
+.admin-header__badge {
+  margin-left: auto;
+  font-size: 12px;
+  color: #9ca3af;
+  background: #f3f4f6;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-weight: 500;
+}
+
+.admin-header__icon {
+  color: #fff;
+  stroke: #fff;
+}

--- a/src/components/admin/layout/AdminHeader.jsx
+++ b/src/components/admin/layout/AdminHeader.jsx
@@ -1,58 +1,20 @@
+import "./AdminHeader.css";
 export default function AdminHeader({ Icon, ICONS }) {
   return (
-    <header
-      style={{
-        background: "#fff",
-        borderBottom: "1px solid #f0f0f0",
-        padding: "0 32px",
-        display: "flex",
-        alignItems: "center",
-        height: 60,
-        gap: 12,
-        position: "sticky",
-        top: 0,
-        zIndex: 10,
-      }}
-    >
-      <div
-        style={{
-          width: 28,
-          height: 28,
-          borderRadius: 7,
-          background: "#111",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
+    <header className="admin-header">
+      <div className="admin-header__logo">
         <Icon
           d={ICONS.grid}
           size={14}
-          style={{ color: "#fff", stroke: "#fff" }}
+          className="admin-header__icon"
         />
       </div>
 
-      <span
-        style={{
-          fontWeight: 700,
-          fontSize: 15,
-          letterSpacing: "-.2px",
-        }}
-      >
+      <span className="admin-header__title">
         Admin
       </span>
 
-      <span
-        style={{
-          marginLeft: "auto",
-          fontSize: 12,
-          color: "#9ca3af",
-          background: "#f3f4f6",
-          padding: "3px 10px",
-          borderRadius: 99,
-          fontWeight: 500,
-        }}
-      >
+      <span className="admin-header__badge">
         Panel de Control
       </span>
     </header>

--- a/src/components/admin/layout/AdminSidebar.css
+++ b/src/components/admin/layout/AdminSidebar.css
@@ -1,0 +1,56 @@
+.admin-sidebar {
+  width: 200px;
+  background: #fff;
+  border-right: 1px solid #f0f0f0;
+  padding: 24px 12px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.admin-sidebar__group-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 14px;
+  border-radius: 9px;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: #6b7280;
+  font-weight: 500;
+  font-size: 13.5px;
+  width: 100%;
+}
+
+.admin-sidebar__label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.admin-sidebar__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-radius: 9px;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: #6b7280;
+  font-weight: 500;
+  font-size: 13.5px;
+  width: 100%;
+}
+
+.admin-sidebar__item--active {
+  background: #f3f4f6;
+  color: #111;
+  font-weight: 600;
+}
+
+.admin-sidebar__child {
+  padding: 9px 14px 9px 34px;
+}

--- a/src/components/admin/layout/AdminSidebar.jsx
+++ b/src/components/admin/layout/AdminSidebar.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import "./AdminSidebar.css";
 
 export default function AdminSidebar({
   tab,
@@ -9,46 +10,16 @@ export default function AdminSidebar({
   const [tablesOpen, setTablesOpen] = useState(true);
 
   return (
-    <aside
-      style={{
-        width: 200,
-        background: "#fff",
-        borderRight: "1px solid #f0f0f0",
-        padding: "24px 12px",
-        flexShrink: 0,
-        display: "flex",
-        flexDirection: "column",
-        gap: 4,
-      }}
-    >
+    <aside className="admin-sidebar">
       {TABS.map((t) => {
         if (t.children) {
           return (
             <div key={t.id}>
               <button
                 onClick={() => setTablesOpen(!tablesOpen)}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "9px 14px",
-                  borderRadius: 9,
-                  border: "none",
-                  cursor: "pointer",
-                  background: "transparent",
-                  color: "#6b7280",
-                  fontWeight: 500,
-                  fontSize: 13.5,
-                  width: "100%",
-                }}
+                className="admin-sidebar__group-btn"
               >
-                <span
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 10,
-                  }}
-                >
+                <span className="admin-sidebar__label">
                   <Icon d={t.icon} size={16} />
                   {t.label}
                 </span>
@@ -63,29 +34,11 @@ export default function AdminSidebar({
                   <button
                     key={child.id}
                     onClick={() => setTab(child.id)}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 10,
-                      padding: "9px 14px 9px 34px",
-                      borderRadius: 9,
-                      border: "none",
-                      cursor: "pointer",
-                      background:
-                        tab === child.id
-                          ? "#f3f4f6"
-                          : "transparent",
-                      color:
-                        tab === child.id
-                          ? "#111"
-                          : "#6b7280",
-                      fontWeight:
-                        tab === child.id
-                          ? 600
-                          : 500,
-                      fontSize: 13.5,
-                      width: "100%",
-                    }}
+                    className={`
+                    admin-sidebar__item
+                    admin-sidebar__child
+                    ${tab === child.id ? "admin-sidebar__item--active" : ""}
+                  `}
                   >
                     <Icon
                       d={child.icon}
@@ -102,29 +55,10 @@ export default function AdminSidebar({
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              padding: "9px 14px",
-              borderRadius: 9,
-              border: "none",
-              cursor: "pointer",
-              background:
-                tab === t.id
-                  ? "#f3f4f6"
-                  : "transparent",
-              color:
-                tab === t.id
-                  ? "#111"
-                  : "#6b7280",
-              fontWeight:
-                tab === t.id
-                  ? 600
-                  : 500,
-              fontSize: 13.5,
-              width: "100%",
-            }}
+            className={`
+              admin-sidebar__item
+              ${tab === t.id ? "admin-sidebar__item--active" : ""}
+            `}
           >
             <Icon d={t.icon} size={16} />
             {t.label}

--- a/src/components/admin/rooms/Room.css
+++ b/src/components/admin/rooms/Room.css
@@ -1,0 +1,4 @@
+.room-actions {
+  display: flex;
+  gap: 8px;
+}

--- a/src/components/admin/rooms/RoomActions.jsx
+++ b/src/components/admin/rooms/RoomActions.jsx
@@ -1,4 +1,5 @@
 import AdminActionButton from "../ui/AdminActionButton";
+import "./Room.css";
 
 export default function RoomActions({
     room,
@@ -6,12 +7,7 @@ export default function RoomActions({
     onDelete,
 }) {
     return (
-        <div
-            style={{
-                display: "flex",
-                gap: 8,
-            }}
-        >
+        <div className="room-actions">
             <AdminActionButton
                 icon="Edit2"
                 title="Editar sala"

--- a/src/components/admin/stats/DashboardStats.css
+++ b/src/components/admin/stats/DashboardStats.css
@@ -1,0 +1,69 @@
+.dashboard-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.dashboard-subtitle {
+  font-size: 13px;
+  color: #9ca3af;
+  margin-bottom: 24px;
+}
+
+.dashboard-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.dashboard-grid-4 {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+
+.dashboard-expired {
+  margin-top: 14px;
+  max-width: 260px;
+}
+
+.dashboard-quick-access {
+  margin-top: 28px;
+  background: #fff;
+  border: 1px solid #f0f0f0;
+  border-radius: 14px;
+  padding: 20px 24px;
+}
+
+.dashboard-quick-access-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #9ca3af;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+
+.dashboard-quick-access-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.dashboard-quick-access-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  padding: 9px 16px;
+
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+
+  background: #fff;
+  cursor: pointer;
+
+  font-size: 13.5px;
+  font-weight: 500;
+  color: #374151;
+}

--- a/src/components/admin/stats/DashboardStats.jsx
+++ b/src/components/admin/stats/DashboardStats.jsx
@@ -2,6 +2,7 @@ import StatCard from "./StatCard";
 import Loader from "../ui/Loader";
 import Err from "../ui/Err";
 import { fmt } from "../../../helpers/admin/formatters";
+import "./DashboardStats.css";
 export default function DashboardStats({
   stats,
   loading,
@@ -16,36 +17,17 @@ export default function DashboardStats({
 
   return (
     <div>
-      <h1
-        style={{
-          fontSize: 20,
-          fontWeight: 700,
-          marginBottom: 4,
-        }}
-      >
+      <h1 className="dashboard-title">
         Dashboard
       </h1>
 
-      <p
-        style={{
-          fontSize: 13,
-          color: "#9ca3af",
-          marginBottom: 24,
-        }}
-      >
+      <p className="dashboard-subtitle">
         Resumen general del sistema
       </p>
 
       {stats && (
         <>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "1fr 1fr",
-              gap: 14,
-              marginBottom: 14,
-            }}
-          >
+          <div className="dashboard-grid-2">
             <StatCard
               label="Ingresos totales"
               value={fmt(stats.totalRevenue)}
@@ -61,13 +43,7 @@ export default function DashboardStats({
             />
           </div>
 
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(4, 1fr)",
-              gap: 14,
-            }}
-          >
+          <div className="dashboard-grid-4">
             <StatCard
               label="Total reservas"
               value={stats.totalReservations}
@@ -98,12 +74,7 @@ export default function DashboardStats({
           </div>
 
           {stats.expiredReservations > 0 && (
-            <div
-              style={{
-                marginTop: 14,
-                maxWidth: 260,
-              }}
-            >
+            <div className="dashboard-expired">
               <StatCard
                 label="Expiradas"
                 value={stats.expiredReservations}
@@ -113,34 +84,12 @@ export default function DashboardStats({
             </div>
           )}
 
-          <div
-            style={{
-              marginTop: 28,
-              background: "#fff",
-              border: "1px solid #f0f0f0",
-              borderRadius: 14,
-              padding: "20px 24px",
-            }}
-          >
-            <p
-              style={{
-                fontSize: 12,
-                fontWeight: 600,
-                color: "#9ca3af",
-                letterSpacing: ".5px",
-                textTransform: "uppercase",
-                marginBottom: 14,
-              }}
-            >
+          <div className="dashboard-quick-access">
+            <p className="dashboard-quick-access-title">
               Acceso rápido
             </p>
 
-            <div
-              style={{
-                display: "flex",
-                gap: 10,
-              }}
-            >
+            <div className="dashboard-quick-access-actions">
               {[
                 {
                   label: "Ver reservas",
@@ -161,19 +110,7 @@ export default function DashboardStats({
                 <button
                   key={a.tab}
                   onClick={() => setTab(a.tab)}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                    padding: "9px 16px",
-                    borderRadius: 8,
-                    border: "1px solid #e5e7eb",
-                    background: "#fff",
-                    cursor: "pointer",
-                    fontSize: 13.5,
-                    fontWeight: 500,
-                    color: "#374151",
-                  }}
+                  className="dashboard-quick-access-btn"
                 >
                   <Icon d={a.icon} size={15} />
                   {a.label}

--- a/src/components/admin/stats/StatCard.css
+++ b/src/components/admin/stats/StatCard.css
@@ -1,0 +1,34 @@
+.stat-card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 22px 24px;
+  border: 1px solid #f0f0f0;
+  box-shadow: 0 1px 3px rgba(0,0,0,.05);
+
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.stat-card__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 10px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.stat-card__value {
+  font-size: 23px;
+  font-weight: 700;
+  color: #111;
+}
+
+.stat-card__label {
+  font-size: 12.5px;
+  color: #9ca3af;
+  margin-top: 3px;
+  font-weight: 500;
+}

--- a/src/components/admin/stats/StatCard.jsx
+++ b/src/components/admin/stats/StatCard.jsx
@@ -1,3 +1,4 @@
+import "./StatCard.css";
 const Icon = ({ d, size = 18 }) => (
   <svg
     width={size}
@@ -20,52 +21,23 @@ export default function StatCard({
   accent,
 }) {
   return (
-    <div
-      style={{
-        background: "#fff",
-        borderRadius: 14,
-        padding: "22px 24px",
-        border: "1px solid #f0f0f0",
-        boxShadow: "0 1px 3px rgba(0,0,0,.05)",
-        display: "flex",
-        alignItems: "flex-start",
-        gap: 16,
-      }}
-    >
+    <div className="stat-card">
       <div
+        className="stat-card__icon"
         style={{
-          width: 42,
-          height: 42,
-          borderRadius: 10,
           background: accent + "18",
           color: accent,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
         }}
       >
         <Icon d={icon} size={20} />
       </div>
 
       <div>
-        <div
-          style={{
-            fontSize: 23,
-            fontWeight: 700,
-            color: "#111",
-          }}
-        >
+        <div className="stat-card__value">
           {value}
         </div>
 
-        <div
-          style={{
-            fontSize: 12.5,
-            color: "#9ca3af",
-            marginTop: 3,
-            fontWeight: 500,
-          }}
-        >
+        <div className="stat-card__label">
           {label}
         </div>
       </div>

--- a/src/components/admin/styles/admin-layout.css
+++ b/src/components/admin/styles/admin-layout.css
@@ -1,0 +1,12 @@
+.admin-inline-actions {
+  display:flex;
+  align-items:center;
+  gap:10px;
+}
+
+.admin-center-cell {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  height:60px;
+}

--- a/src/components/admin/tables/AdminTable.jsx
+++ b/src/components/admin/tables/AdminTable.jsx
@@ -1,32 +1,17 @@
+import "./Table.css";
 export default function AdminTable({
   cols = [],
   rows = [],
   emptyMsg = "Sin datos",
 }) {
   return (
-    <div style={{ overflowX: "auto" }}>
-      <table
-        style={{
-          width: "100%",
-          borderCollapse: "collapse",
-          fontSize: 13.5,
-        }}
-      >
+    <div className="admin-table-wrapper">
+      <table className="admin-table">
         <thead>
           <tr>
             {cols.map((c) => (
               <th
                 key={c.key}
-                style={{
-                  textAlign: "left",
-                  padding: "10px 14px",
-                  color: "#9ca3af",
-                  fontWeight: 600,
-                  fontSize: 11.5,
-                  letterSpacing: ".6px",
-                  textTransform: "uppercase",
-                  borderBottom: "1px solid #f3f4f6",
-                }}
               >
                 {c.label}
               </th>
@@ -39,10 +24,7 @@ export default function AdminTable({
             <tr>
               <td
                 colSpan={cols.length}
-                style={{
-                  padding: "32px 0",
-                  textAlign: "center",
-                }}
+                className="admin-table-empty"
               >
                 {emptyMsg}
               </td>
@@ -53,11 +35,6 @@ export default function AdminTable({
                 {cols.map((c) => (
                   <td
                     key={c.key}
-                    style={{
-                      padding: "11px 14px",
-                      verticalAlign: "middle",
-                      height: 60,
-                    }}
                   >
                     {c.render
                       ? c.render(row)

--- a/src/components/admin/tables/DataTable.jsx
+++ b/src/components/admin/tables/DataTable.jsx
@@ -1,6 +1,7 @@
 import Loader from "../ui/Loader";
 import Err from "../ui/Err";
 import AdminTable from "./AdminTable";
+import "./Table.css";
 
 export default function DataTable({
   loading,
@@ -10,14 +11,7 @@ export default function DataTable({
   emptyMsg,
 }) {
   return (
-    <div
-      style={{
-        background: "#fff",
-        borderRadius: 14,
-        border: "1px solid #f0f0f0",
-        overflow: "hidden",
-      }}
-    >
+    <div className="admin-table-container">
       {loading && <Loader />}
 
       {error && <Err msg={error} />}

--- a/src/components/admin/tables/Table.css
+++ b/src/components/admin/tables/Table.css
@@ -1,0 +1,45 @@
+/* AdminTable Style */
+
+.admin-table-wrapper {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+.admin-table th {
+  text-align: left;
+  padding: 10px 14px;
+  color: #9ca3af;
+  font-weight: 600;
+  font-size: 11.5px;
+  letter-spacing: .6px;
+  text-transform: uppercase;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.admin-table td {
+  padding: 11px 14px;
+  vertical-align: middle;
+  height: 60px;
+}
+
+.admin-table-empty {
+  padding: 32px 0;
+  text-align: center;
+}
+
+/* DataTable Style */
+
+.data-table-container {
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid #f0f0f0;
+  overflow: hidden;
+}
+
+
+/* DataTable Style */

--- a/src/components/admin/ui/Err.jsx
+++ b/src/components/admin/ui/Err.jsx
@@ -1,13 +1,6 @@
 export default function Err({ msg }) {
   return (
-    <div
-      style={{
-        padding: "32px",
-        textAlign: "center",
-        color: "#ef4444",
-        fontSize: 13.5,
-      }}
-    >
+    <div className="admin-error">
       {msg}
     </div>
   );

--- a/src/components/admin/ui/Loader.jsx
+++ b/src/components/admin/ui/Loader.jsx
@@ -1,13 +1,7 @@
 export default function Loader() {
   return (
-    <div
-      style={{
-        textAlign: "center",
-        padding: "48px 0",
-        color: "#d1d5db",
-      }}
-    >
-      <div style={{ fontSize: 13 }}>
+    <div className="admin-loader">
+      <div className="admin-loader__text">
         Cargando…
       </div>
     </div>

--- a/src/components/admin/ui/styles/Err.css
+++ b/src/components/admin/ui/styles/Err.css
@@ -1,0 +1,6 @@
+.admin-error {
+  padding: 32px;
+  text-align: center;
+  color: #ef4444;
+  font-size: 13.5px;
+}

--- a/src/components/admin/ui/styles/Loader.css
+++ b/src/components/admin/ui/styles/Loader.css
@@ -1,0 +1,9 @@
+.admin-loader {
+  text-align: center;
+  padding: 48px 0;
+  color: #d1d5db;
+}
+
+.admin-loader__text {
+  font-size: 13px;
+}

--- a/src/components/admin/users/UserStatusToggle.css
+++ b/src/components/admin/users/UserStatusToggle.css
@@ -1,0 +1,21 @@
+.user-status-toggle {
+  width: 42px;
+  height: 18px;
+  border-radius: 999px;
+  position: relative;
+  transition: .2s;
+}
+
+.user-status-toggle__thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+
+  position: absolute;
+  top: 2px;
+  left: 2px;
+
+  transition: .2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,.15);
+}

--- a/src/components/admin/users/UserStatusToggle.jsx
+++ b/src/components/admin/users/UserStatusToggle.jsx
@@ -1,4 +1,5 @@
 import Swal from "sweetalert2";
+import "./UserStatusToggle.css";
 
 export default function UserStatusToggle({
   user,
@@ -47,39 +48,28 @@ export default function UserStatusToggle({
 
   return (
     <div
+      className="user-status-toggle"
       onClick={handleClick}
       style={{
-        width: 42,
-        height: 18,
-        borderRadius: 999,
         background: user.enabled
           ? "#10b981"
           : "#d1d5db",
-        position: "relative",
+
         cursor: isCurrentUsername
           ? "not-allowed"
           : "pointer",
-        transition: ".2s",
+
         opacity: isCurrentUsername
           ? 0.6
           : 1,
       }}
     >
       <div
+        className="user-status-toggle__thumb"
         style={{
-          width: 14,
-          height: 14,
-          borderRadius: "50%",
-          background: "#fff",
-          position: "absolute",
-          top: 2,
-          left: 2,
           transform: user.enabled
             ? "translateX(24px)"
             : "translateX(0)",
-          transition: ".2s",
-          boxShadow:
-            "0 1px 3px rgba(0,0,0,.15)",
         }}
       />
     </div>


### PR DESCRIPTION
En este PR se cubrio los siguientes archivos:

- AdminHeader
- AdminSidebar
- DashboardStats
- StatCard
- AdminTable
- DataTable
- Loader
- Err
- UserStatusToggle
- RoomActions
- userColumns

Donde se migro la mayor parte  de  los estilos inline de los componentes  a archivos css reutilizables 

-------
closes #139 