### PR TITLE
refactor: extraer estilos compartidos de formularios administrativos

### DIFF
--- a/src/components/admin/forms/AdminForm.css
+++ b/src/components/admin/forms/AdminForm.css
@@ -1,0 +1,89 @@
+.admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.admin-form-label {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: #9ca3af;
+}
+
+.admin-form-hint {
+  text-transform: none;
+  font-weight: 400;
+  color: #d1d5db;
+  margin-left: 4px;
+}
+
+.admin-form-error {
+  font-size: 11px;
+  color: #ef4444;
+  margin: 0;
+}
+
+.admin-form-input-wrapper {
+  position: relative;
+}
+
+.admin-form-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #9ca3af;
+}
+
+.admin-form-input {
+  height: 36px;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  font-family: inherit;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  color: #111827;
+}
+
+.admin-form-footer {
+  border-top: 1px solid #f3f4f6;
+  padding-top: 8px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.admin-form-submit {
+  height: 34px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.admin-form-submit:disabled {
+  cursor: not-allowed;
+}
+
+.admin-form-spin {
+  animation: admin-spin 1s linear infinite;
+}
+
+@keyframes admin-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/admin/rooms/RoomForm.jsx
+++ b/src/components/admin/rooms/RoomForm.jsx
@@ -1,16 +1,14 @@
 import { useState, useRef, useEffect } from "react";
 import { Building2, Users, MapPin, List, Camera, Loader2, Plus, } from "lucide-react";
-
+import "../forms/AdminForm.css";
 function Field({ label, hint, error, children, }) {
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 4, }}>
-      <label style={{ fontSize: 11, fontWeight: 500, textTransform: "uppercase", letterSpacing: ".5px", color: "#9ca3af", }}>
+    <div className="admin-form-field">
+      <label className="admin-form-label">
         {label}
 
         {hint && (
-          <span
-            style={{ textTransform: "none", fontWeight: 400, color: "#d1d5db", marginLeft: 4, }}
-          >
+          <span className="admin-form-hint">
             {hint}
           </span>
         )}
@@ -19,9 +17,7 @@ function Field({ label, hint, error, children, }) {
       {children}
 
       {error && (
-        <p
-          style={{ fontSize: 11, color: "#ef4444", margin: 0, }}
-        >
+        <p className="admin-form-error">
           {error}
         </p>
       )}
@@ -29,40 +25,26 @@ function Field({ label, hint, error, children, }) {
   );
 }
 
-const inputStyle = {
-  height: 36,
-  width: "100%",
-  boxSizing: "border-box",
-  padding: "0 10px 0 32px",
-  fontSize: 13,
-  fontFamily: "inherit",
-  background: "#f9fafb",
-  border: "1px solid #e5e7eb",
-  borderRadius: 8,
-  color: "#111827",
-};
-
 function IconInput({
   icon: Icon,
   dollar,
   ...props
 }) {
   return (
-    <div
-      style={{
-        position: "relative",
-      }}
-    >
+    <div className="admin-form-input-wrapper">
       {Icon && (
         <Icon
           size={14}
-          style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#9ca3af", }}
+          className="admin-form-icon"
         />
       )}
 
       {dollar && (
         <span
-          style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#9ca3af", fontSize: 13, }}
+          className="admin-form-icon"
+          style={{
+            fontSize: 13,
+          }}
         >
           $
         </span>
@@ -70,8 +52,9 @@ function IconInput({
 
       <input
         {...props}
+        className="admin-form-input"
         style={{
-          ...inputStyle, paddingLeft:
+          paddingLeft:
             Icon || dollar
               ? 32
               : 10,
@@ -181,7 +164,7 @@ export default function RoomForm({ onSubmit, loading, initialData, isEdit = fals
   return (
     <form
       onSubmit={submit}
-      style={{ display: "flex", flexDirection: "column", gap: 12, }}
+      className="admin-form"
     >
       <Field label="Nombre" error={errors.name}
       >
@@ -201,7 +184,12 @@ export default function RoomForm({ onSubmit, loading, initialData, isEdit = fals
             e.target.value
           )
         }
-          style={{ ...inputStyle, padding: 10, height: "auto", resize: "none", }}
+          className="admin-form-input"
+          style={{
+            padding: 10,
+            height: "auto",
+            resize: "none",
+          }}
         />
       </Field>
 
@@ -403,38 +391,26 @@ export default function RoomForm({ onSubmit, loading, initialData, isEdit = fals
         )}
       </Field>
 
-      <div
-        style={{ borderTop: "1px solid #f3f4f6", paddingTop: 8, display: "flex", justifyContent: "flex-end", }}
-      >
+      <div className="admin-form-footer">
         <button
           type="submit"
           disabled={loading}
+          className="admin-form-submit"
           style={{
-            height: 34,
-            padding: "0 16px",
-            border: "none",
-            borderRadius: 8,
             background:
               loading
                 ? "#93c5fd"
                 : "#1d4ed8",
-            color: "#fff",
             cursor:
               loading
                 ? "not-allowed"
                 : "pointer",
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
           }}
         >
           {loading ? (
             <Loader2
               size={14}
-              style={{
-                animation:
-                  "spin 1s linear infinite",
-              }}
+              className="admin-form-spin"
             />
           ) : (
             <Plus size={14} />
@@ -447,16 +423,6 @@ export default function RoomForm({ onSubmit, loading, initialData, isEdit = fals
               : "Crear sala"}
         </button>
       </div>
-
-      <style>
-        {`
-          @keyframes spin {
-            to {
-              transform: rotate(360deg);
-            }
-          }
-        `}
-      </style>
     </form>
   );
 }

--- a/src/components/admin/users/AdminForm.jsx
+++ b/src/components/admin/users/AdminForm.jsx
@@ -3,6 +3,7 @@ import {
   User, Mail, Lock, Eye, EyeOff, Building2,
   Users, MapPin, List, Camera, Loader2, Plus,
 } from "lucide-react";
+import "../forms/AdminForm.css";
 
 function Field({
   label,
@@ -10,35 +11,15 @@ function Field({
   children,
 }) {
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 4,
-      }}
-    >
-      <label
-        style={{
-          fontSize: 11,
-          fontWeight: 500,
-          textTransform: "uppercase",
-          letterSpacing: ".5px",
-          color: "#9ca3af",
-        }}
-      >
+    <div className="admin-form-field">
+      <label className="admin-form-label">
         {label}
       </label>
 
       {children}
 
       {error && (
-        <p
-          style={{
-            fontSize: 11,
-            color: "#ef4444",
-            margin: 0,
-          }}
-        >
+        <p className="admin-form-error">
           {error}
         </p>
       )}
@@ -46,41 +27,23 @@ function Field({
   );
 }
 
-const inputStyle = {
-  height: 36,
-  width: "100%",
-  boxSizing: "border-box",
-  padding: "0 10px 0 32px",
-  fontSize: 13,
-  background: "#f9fafb",
-  border: "1px solid #e5e7eb",
-  borderRadius: 8,
-};
-
 function IconInput({
   icon: Icon,
   ...props
 }) {
   return (
-    <div
-      style={{
-        position: "relative",
-      }}
-    >
+    <div className="admin-form-input-wrapper">
       <Icon
         size={14}
-        style={{
-          position: "absolute",
-          left: 10,
-          top: "50%",
-          transform: "translateY(-50%)",
-          color: "#9ca3af",
-        }}
+        className="admin-form-icon"
       />
 
       <input
         {...props}
-        style={inputStyle}
+        className="admin-form-input"
+        style={{
+          padding: "0 10px 0 32px",
+        }}
       />
     </div>
   );
@@ -191,11 +154,7 @@ export default function UserForm({
   return (
     <form
       onSubmit={submit}
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-      }}
+      className="admin-form"
     >
       <Field
         label="Usuario"
@@ -233,21 +192,13 @@ export default function UserForm({
         error={errors.password}
       >
         <div
-          style={{
-            position: "relative",
-            width: "100%",
-          }}
+          className="admin-form-input-wrapper"
+          style={{ width: "100%" }}
         >
           <Lock
             size={14}
-            style={{
-              position: "absolute",
-              left: 10,
-              top: "50%",
-              transform: "translateY(-50%)",
-              color: "#9ca3af",
-              zIndex: 1,
-            }}
+            className="admin-form-icon"
+            style={{ zIndex: 1 }}
           />
 
           <input
@@ -257,8 +208,8 @@ export default function UserForm({
               set("password", e.target.value);
               validateField("password", e.target.value);
             }}
+            className="admin-form-input"
             style={{
-              ...inputStyle,
               paddingLeft: 32,
               paddingRight: 40,
             }}
@@ -293,40 +244,22 @@ export default function UserForm({
         </div>
       </Field>
 
-      <div
-        style={{
-          borderTop:
-            "1px solid #f3f4f6",
-          paddingTop: 8,
-          display: "flex",
-          justifyContent: "flex-end",
-        }}
-      >
+      <div className="admin-form-footer">
         <button
           type="submit"
           disabled={loading}
+          className="admin-form-submit"
           style={{
-            height: 34,
-            padding: "0 16px",
-            border: "none",
-            borderRadius: 8,
             background:
               loading
                 ? "#93c5fd"
                 : "#1d4ed8",
-            color: "#fff",
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
           }}
         >
           {loading ? (
             <Loader2
               size={14}
-              style={{
-                animation:
-                  "spin 1s linear infinite",
-              }}
+              className="admin-form-spin"
             />
           ) : (
             <Plus size={14} />
@@ -337,16 +270,6 @@ export default function UserForm({
             : "Crear administrador"}
         </button>
       </div>
-
-      <style>
-        {`
-          @keyframes spin {
-            to {
-              transform: rotate(360deg);
-            }
-          }
-        `}
-      </style>
     </form>
   );
 }


### PR DESCRIPTION
Se refactorizaron los formularios administrativos para reutilizar estilos comunes mediante un archivo CSS compartido, reduciendo la cantidad de estilos inline duplicados y manteniendo el mismo comportamiento visual y funcional.

**Cambios realizados**

- Nuevo archivo compartido
- Se creó AdminForm.css para centralizar estilos reutilizables de formularios administrativos.

**UserForm**
Se migraron estilos del contenedor principal del formulario.

**Beneficios**

- Menor duplicación de estilos entre formularios.
- Mejor mantenibilidad.
- Mayor consistencia visual.
- Base preparada para extraer componentes reutilizables en futuros refactors.
-------
closes #141 