### PR TITLE
feat(admin): implementar cierre de sesión desde panel administrativo

### DIFF
--- a/src/components/admin/layout/AdminHeader.css
+++ b/src/components/admin/layout/AdminHeader.css
@@ -41,3 +41,26 @@
   color: #fff;
   stroke: #fff;
 }
+
+.admin-header__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.admin-header__logout {
+  border: none;
+  background: #111;
+  color: #fff;
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.admin-header__logout:hover {
+  opacity: 0.9;
+}

--- a/src/components/admin/layout/AdminHeader.jsx
+++ b/src/components/admin/layout/AdminHeader.jsx
@@ -1,5 +1,14 @@
+import { useNavigate } from "react-router-dom";
+import { clearAuth } from "../../../utils/authStorage";
 import "./AdminHeader.css";
 export default function AdminHeader({ Icon, ICONS }) {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    clearAuth();
+    navigate("/Login", { replace: true });
+  };
+
   return (
     <header className="admin-header">
       <div className="admin-header__logo">
@@ -10,13 +19,19 @@ export default function AdminHeader({ Icon, ICONS }) {
         />
       </div>
 
-      <span className="admin-header__title">
-        Admin
-      </span>
+      <div className="admin-header__actions">
+        <span className="admin-header__badge">
+          Panel de Control
+        </span>
 
-      <span className="admin-header__badge">
-        Panel de Control
-      </span>
+        <button
+          type="button"
+          onClick={handleLogout}
+          className="admin-header__logout"
+        >
+          Cerrar sesión
+        </button>
+      </div>
     </header>
   );
 }

--- a/src/components/admin/layout/AdminHeader.jsx
+++ b/src/components/admin/layout/AdminHeader.jsx
@@ -1,12 +1,26 @@
 import { useNavigate } from "react-router-dom";
 import { clearAuth } from "../../../utils/authStorage";
 import "./AdminHeader.css";
+import Swal from "sweetalert2";
+
 export default function AdminHeader({ Icon, ICONS }) {
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    clearAuth();
-    navigate("/Login", { replace: true });
+    Swal.fire({
+      title: "¿Cerrar sesión?",
+      text: "Tu sesión actual finalizará.",
+      icon: "question",
+      showCancelButton: true,
+      confirmButtonText: "Cerrar sesión",
+      cancelButtonText: "Cancelar",
+      confirmButtonColor: "#111827",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        clearAuth();
+        navigate("/Login", { replace: true });
+      }
+    });
   };
 
   return (

--- a/src/utils/authStorage.js
+++ b/src/utils/authStorage.js
@@ -1,3 +1,4 @@
+//Obtener datos de autenticación del almacenamiento local o de sesión
 export function getAuthItem(key) {
   return (
     localStorage.getItem(key) ||
@@ -5,7 +6,16 @@ export function getAuthItem(key) {
   );
 }
 
+//Limpiar el almacenamiento local y de sesión
 export function clearAuth() {
-  localStorage.clear();
-  sessionStorage.clear();
+  const keys = [
+    "token",
+    "username",
+    "role"
+  ];
+  
+  keys.forEach((key) => {
+    localStorage.removeItem(key);
+    sessionStorage.removeItem(key);
+  });
 }


### PR DESCRIPTION
En este PR se implementa la funcionalidad de cierre de sesión desde el panel administrativo.

## Cambios realizados

### Autenticación

- Se reutilizó la utilidad `clearAuth()` para centralizar la eliminación de datos de sesión.
- Se mejoró la limpieza de autenticación eliminando únicamente:
  - token
  - role
  - username

### AdminHeader

- Se agregó botón de cierre de sesión.
- Se incorporó confirmación mediante SweetAlert2 antes de finalizar la sesión.
- Se redirige al usuario hacia la pantalla de Login después de cerrar sesión.

### Criterios de aceptación

- [x] Se elimina la sesión correctamente.
- [x] Se eliminan token, rol y usuario.
- [x] Se redirige al Login.
- [x] No es posible acceder nuevamente al panel sin autenticarse.
- [x] Se solicita confirmación antes de cerrar sesión.

-----
closes #149 