### PR TITLE
feat/Consumir perfil autenticado en menú administrativo

### DIFF
--- a/src/api/adminApi.js
+++ b/src/api/adminApi.js
@@ -53,3 +53,8 @@ export const updateUserRole = async (userId, role) => {
   const res = await API.patch(`/admin/users/${userId}/role`, { role });
   return res.data;
 }
+
+export async function getAdminProfile() {
+  const response = await API.get("/admin/profile");
+  return response.data;
+}

--- a/src/components/admin/hooks/useAdminProfile.js
+++ b/src/components/admin/hooks/useAdminProfile.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { getAdminProfile } from "../../../api/adminApi";
+
+export default function useAdminProfile() {
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function loadProfile() {
+      try {
+        setLoading(true);
+
+        const data = await getAdminProfile();
+
+        setProfile(data);
+      } catch {
+        setError("Error al cargar perfil");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadProfile();
+  }, []);
+
+  return {
+    profile,
+    loading,
+    error,
+  };
+}

--- a/src/components/admin/layout/AdminUserMenu.jsx
+++ b/src/components/admin/layout/AdminUserMenu.jsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useState, useRef, useEffect } from "react";
 import { ChevronDown, User, Settings, LogOut } from "lucide-react";
 import { getAuthItem } from "../../../utils/authStorage";
+import useAdminProfile from "../hooks/useAdminProfile";
 import useLogout from "../hooks/useLogout";
 
 import "./AdminUserMenu.css";
@@ -10,8 +11,13 @@ export default function AdminUserMenu() {
     const [open, setOpen] = useState(false);
     const menuRef = useRef(null);
 
-    const username = getAuthItem("username") || "Administrador";
-    const role = getAuthItem("role") || "ROLE_ADMIN";
+    const { profile } = useAdminProfile();
+
+    const username =
+        profile?.username || "Administrador";
+
+    const role =
+        profile?.roles?.[0] || "ROLE_ADMIN";
 
     const roleLabel =
         role === "ROLE_ADMIN"

--- a/src/components/admin/profile/AdminProfile.css
+++ b/src/components/admin/profile/AdminProfile.css
@@ -1,0 +1,45 @@
+.admin-profile {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.admin-profile__header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.admin-profile__header p {
+  margin-top: 6px;
+  color: #6b7280;
+}
+
+.admin-profile__card {
+  background: #fff;
+  border: 1px solid #eceef1;
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 700px;
+}
+
+.admin-profile__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-profile__field:not(:last-child) {
+  margin-bottom: 20px;
+}
+
+.admin-profile__field label {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.admin-profile__field span {
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+}

--- a/src/components/admin/profile/AdminProfile.jsx
+++ b/src/components/admin/profile/AdminProfile.jsx
@@ -1,0 +1,53 @@
+import useAdminProfile from "../hooks/useAdminProfile";
+
+import Loader from "../ui/Loader";
+import Err from "../ui/Err";
+
+import "./AdminProfile.css";
+
+export default function AdminProfile() {
+  const {
+    profile,
+    loading,
+    error,
+  } = useAdminProfile();
+
+  if (loading) return <Loader />;
+
+  if (error) return <Err msg={error} />;
+
+  const role =
+    profile.roles?.includes("ROLE_ADMIN")
+      ? "Administrador"
+      : "Usuario";
+
+  return (
+    <div className="admin-profile">
+      <div className="admin-profile__header">
+        <h1>Mi Perfil</h1>
+
+        <p>
+          Información de la cuenta
+          administrativa.
+        </p>
+      </div>
+
+      <div className="admin-profile__card">
+        <div className="admin-profile__field">
+          <label>Nombre</label>
+          <span>{profile.username}</span>
+        </div>
+
+        <div className="admin-profile__field">
+          <label>Correo</label>
+          <span>{profile.email}</span>
+        </div>
+
+        <div className="admin-profile__field">
+          <label>Rol</label>
+          <span>{role}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/ProfilePage.jsx
+++ b/src/pages/admin/ProfilePage.jsx
@@ -1,0 +1,5 @@
+import AdminProfile from "../../components/admin/profile/AdminProfile";
+
+export default function ProfilePage() {
+  return <AdminProfile />;
+}

--- a/src/routes/AdminRoutes.jsx
+++ b/src/routes/AdminRoutes.jsx
@@ -11,6 +11,7 @@ import ReservationsPage from "../pages/admin/ReservationsPage";
 import PaymentsPage from "../pages/admin/PaymentsPage";
 import RoomsPage from "../pages/admin/RoomsPage";
 import UsersPage from "../pages/admin/UsersPage";
+import ProfilePage from "../pages/admin/ProfilePage";
 
 export default function AdminRoutes() {
   return (
@@ -39,6 +40,11 @@ export default function AdminRoutes() {
         <Route
           path="users"
           element={<UsersPage />}
+        />
+
+        <Route
+          path="profile"
+          element={<ProfilePage />}
         />
 
         <Route


### PR DESCRIPTION
En este PR se consume el endpoint `GET /admin/profile` para mostrar información real del usuario autenticado dentro del menú administrativo.

La información es obtenida desde el endpoint protegido /admin/profile y se muestra utilizando una vista independiente integrada al sistema de rutas administrativas.

## Cambios realizados

### API
- Se agregó la función `getAdminProfile()` para consumir el endpoint `/admin/profile`.

### Hooks
- Se creó el hook `useAdminProfile` para centralizar la carga del perfil autenticado.

### Menú administrativo
- Se eliminó la dependencia de `localStorage` para mostrar nombre y rol.
- Se integró el consumo del perfil autenticado desde backend.
- Se actualizó el nombre mostrado en el menú utilizando la información recibida desde la API.

## Beneficios

- Fuente única de verdad para la información del usuario autenticado.
- Evita inconsistencias entre el backend y los datos almacenados en el navegador.
- Prepara la base para futuras funcionalidades relacionadas con perfil de usuario.

-----
closes #151 