### PR TITLE
Refactorizar consumo de salas públicas y adaptar respuesta paginada

### DIFF
--- a/src/api/roomApi.js
+++ b/src/api/roomApi.js
@@ -1,10 +1,12 @@
 import API from "./axiosConfig";
 import { toUTC } from "../utils/dateUtils";
 
-export const getRooms = async () => {
+export const getPublicRooms = async () => {
   const res = await API.get("/api/rooms");
 
-  return res.data.data || res.data;
+  const data = res.data.data || res.data;
+
+  return data.content || data;
 };
 
 export const getRoomById = async (id) => {

--- a/src/components/RoomCard/RoomList.jsx
+++ b/src/components/RoomCard/RoomList.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import RoomCard from "./RoomCard";
-import { getRooms } from "../../api/roomApi";
+import { getPublicRooms } from "../../api/roomApi";
 
 export default function RoomList() {
   const [rooms, setRooms] = useState([]);
@@ -9,7 +9,7 @@ export default function RoomList() {
   useEffect(() => {
     const loadRooms = async () => {
       try {
-        const data = await getRooms();
+        const data = await getPublicRooms();
         const sorted = [...data].sort((a, b) => a.capacity - b.capacity);
         setRooms(sorted);
       } catch (err) {

--- a/src/pages/UserDashboard/UserDashboard.jsx
+++ b/src/pages/UserDashboard/UserDashboard.jsx
@@ -6,7 +6,7 @@ import EmptyRoomsState from "../../components/ui/EmptyRoomsState";
 import RoomCarousel from "../../components/RoomCard/RoomCarousel";
 import { useLocation } from "react-router-dom";
 import { adjustDateIfPastClosing } from "../../utils/timeUtils";
-import { getRooms, getRoomsAvailability } from "../../api/roomApi";
+import { getPublicRooms, getRoomsAvailability } from "../../api/roomApi";
 import { getReservations } from "../../api/reservationApi";
 
 export default function UserDashboard() {
@@ -30,7 +30,7 @@ export default function UserDashboard() {
 
   const loadAllRooms = async () => {
     try {
-      const data = await getRooms();
+      const data = await getPublicRooms();
       setFiltered(Array.isArray(data) ? data : []);
     } catch (err) {
       console.error(err);
@@ -91,7 +91,7 @@ export default function UserDashboard() {
 
     const [availabilityRoomsRes, allRoomsRes] = await Promise.all([
       getRoomsAvailability(adjustedFilters),
-      getRooms()
+      getPublicRooms()
     ]);
 
     // RESPUESTAS


### PR DESCRIPTION
En este PR se refactorizó el consumo de salas públicas para diferenciarlo del consumo utilizado por el panel administrativo.

### Cambios realizados

- Se renombró `getRooms()` a `getPublicRooms()` para hacer explícito que corresponde al consumo de la vista pública.
- Se actualizaron las referencias en los componentes que muestran salas públicas.
- Se adaptó el método para soportar la nueva respuesta paginada del backend, retornando `content` cuando corresponde.

### Beneficios

- Se evita confusión entre los métodos utilizados por el panel administrativo y la aplicación pública.
- Se mantiene compatibilidad con el nuevo formato de respuesta paginada.
- Se mejora la legibilidad y mantenibilidad del código.