### PR TITLE
Fix/estandarizar ruta login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ function LayoutWrapper() {
   const location = useLocation();
 
   // rutas donde NO se mostrará el layout general (navbar, contenedor, etc.)
-  const hideLayoutRoutes = ["/Login", "/register"];
+  const hideLayoutRoutes = ["/login", "/register"];
   const shouldHideLayout = hideLayoutRoutes.includes(location.pathname);
 
   return (
@@ -63,7 +63,7 @@ function LayoutWrapper() {
             path="/reservations/new"
           />
           <Route
-            path="/Login"
+            path="/login"
             element={
               <LoginPage />
             }

--- a/src/components/HeroSection/HeroSection.jsx
+++ b/src/components/HeroSection/HeroSection.jsx
@@ -7,7 +7,7 @@ const HeroSection = () => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate("/Login"); // manda al login
+    navigate("/login"); // manda al login
   };
 
   return (

--- a/src/components/NavBar/Navbar.jsx
+++ b/src/components/NavBar/Navbar.jsx
@@ -46,7 +46,7 @@ const Navbar = () => {
         </ul>
         {/* AUTH */}
         <div className="navbar-auth">
-          <Link to="/Login" className="signin">Iniciar sesión</Link>
+          <Link to="/login" className="signin">Iniciar sesión</Link>
           <Link to="/register" className="signup-btn">Registrarse</Link>
         </div>
       </div>

--- a/src/components/NavbarUser/NavbarUser.jsx
+++ b/src/components/NavbarUser/NavbarUser.jsx
@@ -14,7 +14,7 @@ export default function NavbarUser() {
 
   const handleLogout = () => {
     clearAuth();
-    navigate("/Login");
+    navigate("/login");
   };
 
   // botton sin estilo

--- a/src/components/admin/hooks/useLogout.js
+++ b/src/components/admin/hooks/useLogout.js
@@ -23,7 +23,7 @@ export default function useLogout() {
 
     clearAuth();
 
-    navigate("/Login", {
+    navigate("/login", {
       replace: true,
     });
   };

--- a/src/pages/Login/LoginPage.jsx
+++ b/src/pages/Login/LoginPage.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import React from "react";
 import styles from "./LoginPage.module.css";
 import LoginForm from "../../components/LoginForm/LoginForm";
@@ -10,7 +11,7 @@ function LoginPage() {
         <h1 className={styles.title}>Log in</h1>
         <LoginForm />
         <p className={styles.footer}>
-          Don’t have an account? <a href="/register">Sign up</a>
+          Don’t have an account? <Link to="/register">Sign up</Link>
         </p>
       </div>
 

--- a/src/pages/SignUp/SignUp.jsx
+++ b/src/pages/SignUp/SignUp.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import styles from "../SignUp/SignUp.module.css"
 import SignUpForm from "../../components/SignupForm/SignUpForm";
 import backgroundImg from "../../assets/background.png";
@@ -10,7 +11,7 @@ function SignUp() {
         <h1 className={styles.title}>Sign Up</h1>
         <SignUpForm />
         <p className={styles.footer}>
-          Already have an account? <a href="/login">Log in</a>
+          Already have an account? <Link to="/login">Log in</Link>
         </p>
       </div>
 

--- a/src/pages/SignUp/SignUp.jsx
+++ b/src/pages/SignUp/SignUp.jsx
@@ -10,7 +10,7 @@ function SignUp() {
         <h1 className={styles.title}>Sign Up</h1>
         <SignUpForm />
         <p className={styles.footer}>
-          Already have an account? <a href="/Login">Log in</a>
+          Already have an account? <a href="/login">Log in</a>
         </p>
       </div>
 

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -10,7 +10,7 @@ const ProtectedRoute = ({ children, adminOnly = false }) => {
     sessionStorage.getItem("role");
 
   if (!token) {
-    return <Navigate to="/Login" replace />;
+    return <Navigate to="/login" replace />;
   }
 
   if (adminOnly && role !== "ROLE_ADMIN") {


### PR DESCRIPTION
En este PR se corrige la inconsistencia en la nomenclatura de la ruta de inicio de sesión, estandarizando el uso de `/login` en toda la aplicación.

Además, se reemplazaron enlaces HTML (`<a>`) utilizados para la navegación interna por el componente `Link` de React Router, evitando recargas completas de la página y manteniendo el comportamiento de una Single Page Application (SPA).

## Cambios realizados

- Se cambió la ruta `/Login` por `/login`.
- Se actualizaron todas las referencias que apuntaban a `/Login`.
- Se reemplazaron enlaces HTML por `Link` en las páginas de autenticación.
- Se mantuvo la consistencia de las rutas públicas del proyecto.
-----
closes #156 
