### PR TITLE
feat(admin): mostrar nuevas métricas en el dashboard

### DIFF
--- a/src/components/admin/stats/DashboardStats.css
+++ b/src/components/admin/stats/DashboardStats.css
@@ -67,3 +67,55 @@
   font-weight: 500;
   color: #374151;
 }
+
+.dashboard-section {
+  margin-top: 30px;
+}
+
+.dashboard-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  margin-bottom: 14px;
+}
+
+.dashboard-section-header h2 {
+  font-size: 15px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.dashboard-section-header::after {
+  content: "";
+
+  flex: 1;
+
+  margin-left: 14px;
+
+  height: 1px;
+
+  background: #eceff3;
+}
+
+/* Responsive adjustments */
+@media (max-width: 1200px) {
+  .dashboard-grid-4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard-grid-2,
+  .dashboard-grid-4 {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-quick-access-actions {
+    flex-direction: column;
+  }
+
+  .dashboard-expired {
+    max-width: 100%;
+  }
+}

--- a/src/components/admin/stats/DashboardStats.jsx
+++ b/src/components/admin/stats/DashboardStats.jsx
@@ -4,6 +4,7 @@ import Loader from "../ui/Loader";
 import Err from "../ui/Err";
 import { fmt } from "../../../helpers/admin/formatters";
 import "./DashboardStats.css";
+
 export default function DashboardStats({
   stats,
   loading,
@@ -12,9 +13,134 @@ export default function DashboardStats({
   Icon,
 }) {
   const navigate = useNavigate();
+
   if (loading) return <Loader />;
 
   if (error) return <Err msg={error} />;
+
+  if (!stats) return null;
+
+  const financeMetrics = [
+    {
+      label: "Ingresos totales",
+      value: fmt(stats.totalRevenue),
+      icon: ICONS.dollar,
+      accent: "#10b981",
+    },
+    {
+      label: "Ingresos del mes",
+      value: fmt(stats.monthlyRevenue),
+      icon: ICONS.dollar,
+      accent: "#6366f1",
+    },
+  ];
+
+  const reservationMetrics = [
+    {
+      label: "Total reservas",
+      value: stats.totalReservations,
+      icon: ICONS.list,
+      accent: "#3b82f6",
+    },
+    {
+      label: "Pagadas",
+      value: stats.activeReservations,
+      icon: ICONS.check,
+      accent: "#10b981",
+    },
+    {
+      label: "Pendientes",
+      value: stats.pendingReservations,
+      icon: ICONS.clock,
+      accent: "#f59e0b",
+    },
+    {
+      label: "Canceladas",
+      value: stats.cancelledReservations,
+      icon: ICONS.ban,
+      accent: "#ef4444",
+    },
+    {
+      label: "Reservas hoy",
+      value: stats.todayReservations,
+      icon: ICONS.calendar,
+      accent: "#0284c7",
+    },
+    {
+      label: "Reservas del mes",
+      value: stats.monthReservations,
+      icon: ICONS.calendarCheck,
+      accent: "#4f46e5",
+    },
+  ];
+
+  if (stats.expiredReservations > 0) {
+    reservationMetrics.push({
+      label: "Expiradas",
+      value: stats.expiredReservations,
+      icon: ICONS.clock,
+      accent: "#9ca3af",
+    });
+  }
+
+  const userMetrics = [
+    {
+      label: "Usuarios registrados",
+      value: stats.totalUsers,
+      icon: ICONS.users,
+      accent: "#2563eb",
+    },
+    {
+      label: "Usuarios activos",
+      value: stats.activeUsers,
+      icon: ICONS.user,
+      accent: "#16a34a",
+    },
+    {
+      label: "Usuarios deshabilitados",
+      value: stats.disabledUsers,
+      icon: ICONS.ban,
+      accent: "#dc2626",
+    },
+  ];
+
+  const roomMetrics = [
+    {
+      label: "Salas registradas",
+      value: stats.totalRooms,
+      icon: ICONS.building,
+      accent: "#7c3aed",
+    },
+    {
+      label: "Salas disponibles",
+      value: stats.availableRooms,
+      icon: ICONS.check,
+      accent: "#059669",
+    },
+    {
+      label: "Salas no disponibles",
+      value: stats.unavailableRooms,
+      icon: ICONS.clock,
+      accent: "#ea580c",
+    },
+  ];
+
+  const renderSection = (title, metrics, columns = "dashboard-grid-4") => (
+    <section className="dashboard-section">
+      <div className="dashboard-section-header">
+        <h2>{title}</h2>
+      </div>
+
+      <div className={columns}>
+        {metrics.map((metric) => (
+          <StatCard
+            key={metric.label}
+            {...metric}
+          />
+        ))}
+      </div>
+    </section>
+  );
 
   return (
     <div>
@@ -26,101 +152,65 @@ export default function DashboardStats({
         Resumen general del sistema
       </p>
 
-      {stats && (
-        <>
-          <div className="dashboard-grid-2">
-            <StatCard
-              label="Ingresos totales"
-              value={fmt(stats.totalRevenue)}
-              icon={ICONS.dollar}
-              accent="#10b981"
-            />
-
-            <StatCard
-              label="Ingresos del mes"
-              value={fmt(stats.monthlyRevenue)}
-              icon={ICONS.dollar}
-              accent="#6366f1"
-            />
-          </div>
-
-          <div className="dashboard-grid-4">
-            <StatCard
-              label="Total reservas"
-              value={stats.totalReservations}
-              icon={ICONS.list}
-              accent="#3b82f6"
-            />
-
-            <StatCard
-              label="Activas (pagadas)"
-              value={stats.activeReservations}
-              icon={ICONS.check}
-              accent="#10b981"
-            />
-
-            <StatCard
-              label="Pendientes"
-              value={stats.pendingReservations}
-              icon={ICONS.clock}
-              accent="#f59e0b"
-            />
-
-            <StatCard
-              label="Canceladas"
-              value={stats.cancelledReservations}
-              icon={ICONS.ban}
-              accent="#ef4444"
-            />
-          </div>
-
-          {stats.expiredReservations > 0 && (
-            <div className="dashboard-expired">
-              <StatCard
-                label="Expiradas"
-                value={stats.expiredReservations}
-                icon={ICONS.clock}
-                accent="#9ca3af"
-              />
-            </div>
-          )}
-
-          <div className="dashboard-quick-access">
-            <p className="dashboard-quick-access-title">
-              Acceso rápido
-            </p>
-
-            <div className="dashboard-quick-access-actions">
-              {[
-                {
-                  label: "Ver reservas",
-                  path: "/admin/reservations",
-                  icon: ICONS.list,
-                },
-                {
-                  label: "Ver pagos",
-                  path: "/admin/payments",
-                  icon: ICONS.credit,
-                },
-                {
-                  label: "Ver salas",
-                  path: "/admin/rooms",
-                  icon: ICONS.room,
-                },
-              ].map((a) => (
-                <button
-                  key={a.path}
-                  onClick={() => navigate(a.path)}
-                  className="dashboard-quick-access-btn"
-                >
-                  <Icon d={a.icon} size={15} />
-                  {a.label}
-                </button>
-              ))}
-            </div>
-          </div>
-        </>
+      {renderSection(
+        "",
+        financeMetrics,
+        "dashboard-grid-2"
       )}
+
+      {renderSection(
+        "Reservas",
+        reservationMetrics
+      )}
+
+      {renderSection(
+        "Usuarios",
+        userMetrics
+      )}
+
+      {renderSection(
+        "Salas",
+        roomMetrics
+      )}
+
+      <div className="dashboard-quick-access">
+        <p className="dashboard-quick-access-title">
+          Acceso rápido
+        </p>
+
+        <div className="dashboard-quick-access-actions">
+          {[
+            {
+              label: "Ver reservas",
+              path: "/admin/reservations",
+              icon: ICONS.list,
+            },
+            {
+              label: "Ver pagos",
+              path: "/admin/payments",
+              icon: ICONS.credit,
+            },
+            {
+              label: "Ver salas",
+              path: "/admin/rooms",
+              icon: ICONS.room,
+            },
+          ].map((action) => (
+            <button
+              key={action.path}
+              onClick={() => navigate(action.path)}
+              className="dashboard-quick-access-btn"
+            >
+              <Icon
+                d={action.icon}
+                size={15}
+              />
+
+              {action.label}
+            </button>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/helpers/admin/icons.js
+++ b/src/helpers/admin/icons.js
@@ -43,4 +43,11 @@ export const ICONS = {
 
   users:
     "M17 20h5V4H2v16h5M9 20V10m6 10V14",
+
+  user:
+    "M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z",
+
+  building:
+    "M3 21h18M5 21V7l7-4 7 4v14",
+
 };


### PR DESCRIPTION
Este PR actualiza el dashboard administrativo para mostrar las nuevas métricas proporcionadas por el backend y reorganiza la interfaz para mejorar la lectura de la información.

## Cambios realizados

### Nuevas métricas

Se agregan tarjetas para visualizar:

- Usuarios registrados.
- Usuarios activos.
- Usuarios deshabilitados.
- Salas registradas.
- Salas disponibles.
- Salas no disponibles.
- Reservas creadas hoy.
- Reservas creadas este mes.

### Refactorización

- Se eliminó la repetición de múltiples componentes `StatCard`.
- Las métricas ahora se generan mediante arreglos y `map()`, facilitando el mantenimiento y futuras ampliaciones.

### Organización visual

El dashboard ahora agrupa la información en secciones:

- Finanzas
- Reservas
- Usuarios
- Salas

Esto mejora la lectura y prepara el dashboard para incorporar futuras gráficas y widgets.

### Responsive

- Se mejoró la distribución de las tarjetas en pantallas pequeñas.
- Se mantiene el diseño existente del panel administrativo.

--------
closes #162 