### PR TITLE
Implementar gráfica de ocupación de salas en dashboard

### DIFF
--- a/src/api/adminDashboardApi.js
+++ b/src/api/adminDashboardApi.js
@@ -32,3 +32,9 @@ export const getRevenueChart = async (period) => {
   });
   return response.data;
 };
+
+// Room occupancy Chart
+export const getRoomOccupancyChart = async () => {
+  const response = await API.get("/admin/dashboard/room-occupancy");
+  return response.data;
+};

--- a/src/components/admin/hooks/useRoomOccupancyChart.jsx
+++ b/src/components/admin/hooks/useRoomOccupancyChart.jsx
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { getRoomOccupancyChart } from "../../../api/adminDashboardApi";
+
+export default function useRoomOccupancyChart() {
+
+    const [chartData, setChartData] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const loadChartData = useCallback(async () => {
+
+        setLoading(true);
+        setError(null);
+
+        try {
+
+            const data = await getRoomOccupancyChart();
+            setChartData(data);
+
+        } catch {
+
+            setError("Error al cargar la ocupación de salas");
+
+        } finally {
+
+            setLoading(false);
+
+        }
+
+    }, []);
+
+    useEffect(() => {
+        loadChartData();
+    }, [loadChartData]);
+
+    return {
+        chartData,
+        loading,
+        error,
+        reloadChart: loadChartData,
+    };
+
+}

--- a/src/components/admin/stats/DashboardChart.jsx
+++ b/src/components/admin/stats/DashboardChart.jsx
@@ -21,11 +21,12 @@ export default function DashboardChart({
 
                 <h3 className="chart-title">{title}</h3>
 
+                {period &&setPeriod && (
                 <CustomSelect
                     value={period}
                     onValueChange={setPeriod}
                     options={Object.values(CHART_PERIODS)}
-                />
+                />)}
 
             </div>
 

--- a/src/components/admin/stats/DashboardRoomOccupancyChart.jsx
+++ b/src/components/admin/stats/DashboardRoomOccupancyChart.jsx
@@ -1,0 +1,81 @@
+import {
+    ResponsiveContainer, BarChart, Bar,
+    CartesianGrid, Tooltip, XAxis, YAxis,
+} from "recharts";
+import DashboardChart from "./DashboardChart";
+import RoomOccupancyTooltip from "../ui/RoomOccupancyTooltip";
+
+export default function DashboardRoomOccupancyChart(props) {
+
+    const { data } = props;
+
+    const chartData = [...(data ?? [])].sort(
+        (a, b) => b.occupancyPercentage - a.occupancyPercentage
+    );
+
+    return (
+
+        <DashboardChart {...props}>
+            <ResponsiveContainer
+                width="100%"
+                height="100%"
+            >
+
+                <BarChart
+                    data={chartData}
+                    layout="vertical"
+                    margin={{
+                        top: 10,
+                        right: 20,
+                        left: 15,
+                        bottom: 10,
+                    }}
+                >
+
+                    <CartesianGrid
+                        horizontal={false}
+                        stroke="#f3f4f6"
+                    />
+
+                    <XAxis
+                        type="number"
+                        domain={[0, 100]}
+                        axisLine={false}
+                        tickLine={false}
+                        tick={{
+                            fontSize: 11,
+                            fill: "#6b7280",
+                        }}
+                    />
+
+                    <YAxis
+                        type="category"
+                        dataKey="roomName"
+                        width={100}
+                        axisLine={false}
+                        tickLine={false}
+                        tick={{
+                            fontSize: 12,
+                            fill: "#374151",
+                        }}
+                    />
+
+                    <Tooltip
+                        cursor={{
+                            fill: "rgba(79,70,229,.06)",
+                        }}
+                        content={<RoomOccupancyTooltip />}
+                    />
+
+                    <Bar
+                        dataKey="occupancyPercentage"
+                        fill="#7c3aed"
+                        radius={[0, 8, 8, 0]}
+                    />
+
+                </BarChart>
+            </ResponsiveContainer>
+        </DashboardChart>
+
+    );
+}

--- a/src/components/admin/stats/DashboardStats.jsx
+++ b/src/components/admin/stats/DashboardStats.jsx
@@ -5,8 +5,9 @@ import Err from "../ui/Err";
 
 import DashboardReservationsChart from "./DashboardReservationsChart";
 import DashboardRevenueChart from "./DashboardRevenueChart";
-import { CHART_PERIODS } from "../../../helpers/admin/chartPeriods";
+import DashboardRoomOccupancyChart from "./DashboardRoomOccupancyChart";
 
+import { CHART_PERIODS } from "../../../helpers/admin/chartPeriods";
 import { fmt } from "../../../helpers/admin/formatters";
 import "./DashboardStats.css";
 
@@ -26,6 +27,10 @@ export default function DashboardStats({
   revenueChartError,
   revenuePeriod,
   setRevenuePeriod,
+
+  roomOccupancyData,
+  roomOccupancyLoading,
+  roomOccupancyError,
 
   ICONS,
   Icon,
@@ -120,6 +125,17 @@ export default function DashboardStats({
           error={revenueChartError}
           period={revenuePeriod}
           setPeriod={setRevenuePeriod}
+        />
+
+      </section>
+
+      <section className="dashboard-chart-grid">
+
+        <DashboardRoomOccupancyChart
+          title="Ranking de salas"
+          data={roomOccupancyData}
+          loading={roomOccupancyLoading}
+          error={roomOccupancyError}
         />
 
       </section>

--- a/src/components/admin/ui/RoomOccupancyTooltip.jsx
+++ b/src/components/admin/ui/RoomOccupancyTooltip.jsx
@@ -1,0 +1,36 @@
+import "./styles/RoomOccupancy.css";
+
+export default function RoomOccupancyTooltip({
+    active,
+    payload,
+}) {
+
+    if (!active || !payload?.length) {
+        return null;
+    }
+
+    const room = payload[0].payload;
+
+    return (
+        <div className="chart-tooltip">
+
+            <p className="chart-tooltip-title">
+                {room.roomName}
+            </p>
+
+            <p className="chart-tooltip-item">
+                Ocupación:<strong> {room.occupancyPercentage}%</strong>
+            </p>
+
+            <p className="chart-tooltip-item">
+                Horas reservadas:<strong> {room.reservedHours}</strong>
+            </p>
+
+            <p className="chart-tooltip-item">
+                Reservas:<strong> {room.reservationCount}</strong>
+            </p>
+
+        </div>
+    );
+
+}

--- a/src/components/admin/ui/styles/RoomOccupancy.css
+++ b/src/components/admin/ui/styles/RoomOccupancy.css
@@ -1,0 +1,30 @@
+
+/* ==========================
+   ROOM OCCUPANCY TOOLTIP
+========================== */
+
+.chart-tooltip {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px 14px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  min-width: 170px;
+}
+
+.chart-tooltip-title {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.chart-tooltip-item {
+  margin: 4px 0;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.chart-tooltip-item strong {
+  color: #111827;
+}

--- a/src/pages/admin/DashboardPage.jsx
+++ b/src/pages/admin/DashboardPage.jsx
@@ -3,6 +3,7 @@ import DashboardStats from "../../components/admin/stats/DashboardStats";
 import useAdminStats from "../../components/admin/hooks/useAdminStats";
 import useReservationsChart from "../../components/admin/hooks/useReservationsChart";
 import useRevenueChart from "../../components/admin/hooks/useRevenueChart";
+import useRoomOccupancyChart from "../../components/admin/hooks/useRoomOccupancyChart";
 
 import Icon from "../../components/admin/ui/Icon";
 import { ICONS } from "../../helpers/admin/icons";
@@ -14,6 +15,7 @@ export default function DashboardPage() {
     loading,
     error,
   } = useAdminStats();
+
   // Reservas
   const {
     chartData,
@@ -22,6 +24,7 @@ export default function DashboardPage() {
     period,
     setPeriod,
   } = useReservationsChart();
+
   // Ingresos
   const {
     chartData: revenueChartData,
@@ -30,6 +33,13 @@ export default function DashboardPage() {
     period: revenuePeriod,
     setPeriod: setRevenuePeriod,
   } = useRevenueChart();
+
+  // Ocupación de salas
+  const {
+    chartData: roomOccupancyData,
+    loading: roomOccupancyLoading,
+    error: roomOccupancyError,
+  } = useRoomOccupancyChart();
 
   return (
     <DashboardStats
@@ -49,6 +59,9 @@ export default function DashboardPage() {
       revenuePeriod={revenuePeriod}
       setRevenuePeriod={setRevenuePeriod}
 
+      roomOccupancyData={roomOccupancyData}
+      roomOccupancyLoading={roomOccupancyLoading}
+      roomOccupancyError={roomOccupancyError}
 
       ICONS={ICONS}
       Icon={Icon}


### PR DESCRIPTION
En este PR se agrega una gráfica que muestre el ranking de ocupación de salas en el dashboard administrativo.

## Cambios realizados

- Se consumió el endpoint de ocupación de salas.
- Se creó un hook para obtener los datos.
- Se implementó la gráfica reutilizando los componentes existentes.
- Se integró la gráfica al dashboard.
- Se agregaron estados de carga y manejo de datos vacíos.
- Se ajustó el diseño para mantener consistencia visual.

## Criterios de aceptación

- [x] Mostrar ranking de salas.
- [x] Mostrar porcentaje de ocupación.
- [x] Mostrar horas reservadas en el tooltip.
- [x] Gráfica responsiva.
- [x] Integración con el diseño actual.

----
closes #166 