### PR TITLE
Implementar actividad reciente en el dashboard administrativo

### DIFF
--- a/src/api/adminDashboardApi.js
+++ b/src/api/adminDashboardApi.js
@@ -38,3 +38,9 @@ export const getRoomOccupancyChart = async () => {
   const response = await API.get("/admin/dashboard/room-occupancy");
   return response.data;
 };
+
+// Recent activities
+export const getRecentActivities = async () => {
+  const response = await API.get("/admin/dashboard/recent-activities");
+  return response.data;
+};

--- a/src/components/admin/activity/RecentActivity.css
+++ b/src/components/admin/activity/RecentActivity.css
@@ -1,0 +1,89 @@
+.recent-activity-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.recent-activity-item {
+    display: flex;
+    gap: 12px;
+    padding: 14px 0;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.recent-activity-item:last-child {
+    border-bottom: none;
+}
+
+.recent-activity-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.recent-activity-icon.payment {
+    background: #ecfdf5;
+    color: #059669;
+}
+
+
+.recent-activity-icon.reservation {
+    background: #eff6ff;
+    color: #2563eb;
+}
+
+.recent-activity-content {
+    flex: 1;
+}
+
+.recent-activity-user {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.recent-activity-description {
+    margin: 2px 0;
+    font-size: 13px;
+    color: #4b5563;
+}
+
+.recent-activity-date {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.recent-activity-list {
+    max-height: 280px;
+    overflow-y: auto;
+}
+
+.recent-activity-empty {
+    height: 100%;
+    display:flex;
+    flex-direction:column;
+    justify-content:center;
+    align-items:center;
+    text-align:center;
+}
+
+.recent-activity-empty-title {
+    margin:0;
+    font-size:15px;
+    font-weight:600;
+    color:#374151;
+}
+
+.recent-activity-empty-description {
+    margin-top:6px;
+    font-size:13px;
+    color:#9ca3af;
+}

--- a/src/components/admin/activity/RecentActivityItem.jsx
+++ b/src/components/admin/activity/RecentActivityItem.jsx
@@ -1,0 +1,56 @@
+import {
+    CalendarClock, CreditCard, ClipboardList,
+} from "lucide-react";
+
+import { formatRelativeDate } from "../../../helpers/admin/dateFormatter";
+
+import "./RecentActivity.css";
+
+export default function RecentActivityItem({ activity }) {
+
+    const activityConfig = {
+
+        Pago: {
+            icon: <CreditCard size={16} />,
+            className: "payment"
+        },
+
+        Reserva: {
+            icon: <ClipboardList size={16} />,
+            className: "reservation"
+        }
+
+    };
+
+    const config = activityConfig[activity.type];
+    return (
+
+        <li className="recent-activity-item">
+
+            <div className={`recent-activity-icon ${config.className}`}>{config.icon}</div>
+
+            <div className="recent-activity-content">
+
+                <p className="recent-activity-user">
+                    {activity.user}
+                </p>
+
+                <p className="recent-activity-description">
+                    {activity.description}
+                </p>
+
+                <div className="recent-activity-date">
+
+                    <CalendarClock size={11} />
+
+                    <span>
+                        {formatRelativeDate(activity.date)}
+                    </span>
+
+                </div>
+            </div>
+        </li>
+
+    );
+
+}

--- a/src/components/admin/activity/RecentActivityList.jsx
+++ b/src/components/admin/activity/RecentActivityList.jsx
@@ -5,7 +5,7 @@ import DashboardChart from "../stats/DashboardChart";
 import RecentActivityItem from "./RecentActivityItem";
 
 export default function RecentActivityList({
-    activities,
+    activities = [],
     loading,
     error,
 }) {
@@ -18,18 +18,34 @@ export default function RecentActivityList({
             loading={loading}
             error={error}
         >
-            <ul className="recent-activity-list">
+            {activities.length === 0 ? (
 
-                {activities.map(activity => (
+                <div className="recent-activity-empty">
 
-                    <RecentActivityItem
-                        key={`${activity.type}-${activity.date}`}
-                        activity={activity}
-                    />
+                    <p className="recent-activity-empty-title">
+                        No hay actividad reciente
+                    </p>
 
-                ))}
+                    <p className="recent-activity-empty-description">
+                        Las acciones del sistema aparecerán aquí
+                    </p>
 
-            </ul>
+                </div>
+
+            ) : (
+                <ul className="recent-activity-list">
+
+                    {activities.map(activity => (
+
+                        <RecentActivityItem
+                            key={`${activity.type}-${activity.date}`}
+                            activity={activity}
+                        />
+
+                    ))}
+
+                </ul>
+            )}
         </DashboardChart>
     );
 

--- a/src/components/admin/activity/RecentActivityList.jsx
+++ b/src/components/admin/activity/RecentActivityList.jsx
@@ -1,0 +1,36 @@
+import Loader from "../ui/Loader";
+import Err from "../ui/Err";
+
+import DashboardChart from "../stats/DashboardChart";
+import RecentActivityItem from "./RecentActivityItem";
+
+export default function RecentActivityList({
+    activities,
+    loading,
+    error,
+}) {
+
+    return (
+
+        <DashboardChart
+            title="Actividad reciente"
+            data={activities}
+            loading={loading}
+            error={error}
+        >
+            <ul className="recent-activity-list">
+
+                {activities.map(activity => (
+
+                    <RecentActivityItem
+                        key={`${activity.type}-${activity.date}`}
+                        activity={activity}
+                    />
+
+                ))}
+
+            </ul>
+        </DashboardChart>
+    );
+
+}

--- a/src/components/admin/hooks/useRecentActivity.js
+++ b/src/components/admin/hooks/useRecentActivity.js
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { getRecentActivities } from "../../../api/adminDashboardApi";
+
+export default function useRecentActivity() {
+
+    const [activities, setActivities] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const loadActivities = useCallback(async () => {
+
+        setLoading(true);
+        setError(null);
+
+        try {
+
+            const data = await getRecentActivities();
+            setActivities(data);
+
+        } catch {
+
+            setError("Error al cargar las actividades recientes");
+
+        } finally {
+
+            setLoading(false);
+
+        }
+
+    }, []);
+
+    useEffect(() => {
+        loadActivities();
+    }, [loadActivities]);
+
+    return {
+        activities,
+        loading,
+        error,
+        reloadActivities: loadActivities,
+    };
+
+}

--- a/src/components/admin/stats/DashboardStats.jsx
+++ b/src/components/admin/stats/DashboardStats.jsx
@@ -6,6 +6,7 @@ import Err from "../ui/Err";
 import DashboardReservationsChart from "./DashboardReservationsChart";
 import DashboardRevenueChart from "./DashboardRevenueChart";
 import DashboardRoomOccupancyChart from "./DashboardRoomOccupancyChart";
+import RecentActivityList from "../activity/RecentActivityList";
 
 import { CHART_PERIODS } from "../../../helpers/admin/chartPeriods";
 import { fmt } from "../../../helpers/admin/formatters";
@@ -31,6 +32,10 @@ export default function DashboardStats({
   roomOccupancyData,
   roomOccupancyLoading,
   roomOccupancyError,
+
+  recentActivities,
+  recentActivitiesLoading,
+  recentActivitiesError,
 
   ICONS,
   Icon,
@@ -136,6 +141,12 @@ export default function DashboardStats({
           data={roomOccupancyData}
           loading={roomOccupancyLoading}
           error={roomOccupancyError}
+        />
+
+        <RecentActivityList
+          activities={recentActivities}
+          loading={recentActivitiesLoading}
+          error={recentActivitiesError}
         />
 
       </section>

--- a/src/helpers/admin/dateFormatter.js
+++ b/src/helpers/admin/dateFormatter.js
@@ -1,0 +1,32 @@
+export function formatRelativeDate(date) {
+
+    const now = new Date();
+    const activityDate = new Date(date);
+
+    const diff =
+        Math.floor(
+            (now - activityDate) / 1000
+        );
+
+    if (diff < 60) {
+        return "Hace unos segundos";
+    }
+
+    if (diff < 3600) {
+        return `Hace ${Math.floor(diff / 60)} minutos`;
+    }
+
+    if (diff < 86400) {
+        return `Hace ${Math.floor(diff / 3600)} horas`;
+    }
+
+    return activityDate.toLocaleDateString(
+        "es-ES",
+        {
+            day: "numeric",
+            month: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+        }
+    );
+}

--- a/src/pages/admin/DashboardPage.jsx
+++ b/src/pages/admin/DashboardPage.jsx
@@ -4,6 +4,7 @@ import useAdminStats from "../../components/admin/hooks/useAdminStats";
 import useReservationsChart from "../../components/admin/hooks/useReservationsChart";
 import useRevenueChart from "../../components/admin/hooks/useRevenueChart";
 import useRoomOccupancyChart from "../../components/admin/hooks/useRoomOccupancyChart";
+import useRecentActivity from "../../components/admin/hooks/useRecentActivity";
 
 import Icon from "../../components/admin/ui/Icon";
 import { ICONS } from "../../helpers/admin/icons";
@@ -41,6 +42,13 @@ export default function DashboardPage() {
     error: roomOccupancyError,
   } = useRoomOccupancyChart();
 
+  // Actividad reciente
+  const {
+    activities,
+    loading: activitiesLoading,
+    error: activitiesError,
+  } = useRecentActivity();
+
   return (
     <DashboardStats
       stats={stats}
@@ -62,6 +70,10 @@ export default function DashboardPage() {
       roomOccupancyData={roomOccupancyData}
       roomOccupancyLoading={roomOccupancyLoading}
       roomOccupancyError={roomOccupancyError}
+
+      recentActivities={activities}
+      recentActivitiesLoading={activitiesLoading}
+      recentActivitiesError={activitiesError}
 
       ICONS={ICONS}
       Icon={Icon}


### PR DESCRIPTION
En este PR se agregó la visualización de actividad reciente dentro del dashboard administrativo, consumiendo el nuevo endpoint de actividades del sistema.

## Cambios realizados

### Consumo de API
- Se agregó la función para consultar:
  - GET `/admin/dashboard/recent-activities`
- Se creó el hook `useRecentActivity` para manejar:
  - carga de información
  - estados de loading
  - errores
  - actualización manual

### Componentes UI
- Se creó `RecentActivityList` para mostrar la lista de actividades.
- Se creó `RecentActivityItem` para reutilizar la representación de cada registro.
- Se integró la sección dentro del dashboard administrativo.

### Mejoras visuales
- Se agregó estado vacío personalizado:
  - "No hay actividad reciente"
  - "Las acciones del sistema aparecerán aquí"
- Se mantuvo el diseño consistente con las tarjetas existentes del dashboard.
- Se reutilizó la estructura visual del componente `DashboardChart`.

### Pruebas
- Se verificó la carga correcta de actividades desde el endpoint.
- Se validó el renderizado de la lista.
- Se validó el estado vacío cuando no existen registros.


----
closes #165 