### PR TITLE
feat: Mantener sidebar fijo durante desplazamiento administrativo

### DIFF
--- a/src/components/admin/layout/AdminSidebar.css
+++ b/src/components/admin/layout/AdminSidebar.css
@@ -1,5 +1,6 @@
 .admin-sidebar {
   width: 200px;
+  height: 100%;
   background: #fff;
   border-right: 1px solid #f0f0f0;
   padding: 24px 12px;
@@ -7,6 +8,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  overflow-y: auto;
 }
 
 .admin-sidebar__group-btn {

--- a/src/layouts/AdminLayout.css
+++ b/src/layouts/AdminLayout.css
@@ -1,7 +1,8 @@
 @import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap");
 
 .admin-layout {
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   background: #f9fafb;
   font-family: "DM Sans", system-ui, sans-serif;
   color: #111;
@@ -9,11 +10,12 @@
 
 .admin-layout__container {
   display: flex;
-  min-height: calc(100vh - 60px);
+  height: calc(100vh - 60px);
 }
 
 .admin-layout__main {
   flex: 1;
+  overflow-y: auto;
   padding: 28px 32px;
   max-width: 1100px;
 }


### PR DESCRIPTION
Se ajustó el layout administrativo para mantener el menú lateral visible durante el desplazamiento del contenido.

## Cambios realizados

- Se configuró el layout principal con altura fija de ventana (`100vh`).
- Se evitó el scroll general de la página administrativa.
- Se habilitó el desplazamiento únicamente en el contenido principal.
- Se mantuvo el sidebar ocupando toda la altura disponible.
- Se evitó la generación de doble scroll en el panel administrativo.

## Archivos modificados

- `AdminLayout.css`
- `AdminSidebar.css`

## Criterios de aceptación

- [x] Sidebar permanece visible durante el scroll.  
- [x] Solo el contenido principal es desplazable.  
- [x] Se mantiene la altura completa del panel administrativo.  
- [x] No se genera doble scroll.  
- [x] Se conserva el comportamiento actual del diseño.

## Pruebas realizadas

- Dashboard con gráficas largas.
- Tablas administrativas con múltiples registros.
- Navegación entre rutas administrativas.

Resultado: correcto.

----
closes #167 